### PR TITLE
v1.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Improved `enumFromName`.
 - Added `IterableEnumExtension`.
+- Added `Type.tryParse`.
 - `EntityReference` and `EntityReferenceList`:
   - improve `fromJson`.
 - Fix `EntityRepository.selectFirstByQuery`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.3.9
+
+- Improved `enumFromName`.
+- Added `IterableEnumExtension`.
+- Fix `EntityRepository.selectFirstByQuery`:
+  - `resolutionRules` wasn't being passed to sub calls.
+
 ## 1.3.8
 
 - Added `APIRequest.id`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Improved `enumFromName`.
 - Added `IterableEnumExtension`.
+- `EntityReference` and `EntityReferenceList`:
+  - improve `fromJson`.
 - Fix `EntityRepository.selectFirstByQuery`:
   - `resolutionRules` wasn't being passed to sub calls.
 

--- a/lib/bones_api.dart
+++ b/lib/bones_api.dart
@@ -2,7 +2,8 @@
 // - Generated with:
 //   ## remove the documentation canonicals from this file first.
 //   $> dart doc --dry-run 2>/tmp/dartdoc.txt
-//   $> cat /tmp/dartdoc.txt | grep "ambiguous reexport " |  awk '{ print $5 }' | sed 's/,//' | awk '{ print "/// {@canonicalFor " $0 "}" }'
+//   $> cat /tmp/dartdoc.txt | grep "ambiguous reexport " |  awk '{ print $5 }' | sed 's/,//' | awk '{ print "/// {@canonicalFor " $0 "}" }' > /tmp/dartdoc-canonicals.txt
+//   $> open /tmp/dartdoc-canonicals.txt
 //   ## then sort the documentation canonicals lines to have a deterministic list.
 //
 /// {@canonicalFor bones_api_authentication.APIAuthentication}
@@ -84,13 +85,11 @@
 /// {@canonicalFor bones_api_entity.ClassReflectionEntityHandler}
 /// {@canonicalFor bones_api_entity.EntityAccessor}
 /// {@canonicalFor bones_api_entity.EntityCache}
-/// {@canonicalFor bones_api_entity.EntityFetcher}
 /// {@canonicalFor bones_api_entity.EntityFieldAccessorGeneric}
 /// {@canonicalFor bones_api_entity.EntityFieldAccessor}
 /// {@canonicalFor bones_api_entity.EntityHandlerProvider}
 /// {@canonicalFor bones_api_entity.EntityHandler}
 /// {@canonicalFor bones_api_entity.EntityProvider}
-/// {@canonicalFor bones_api_entity.EntityReference}
 /// {@canonicalFor bones_api_entity.EntityRepositoryProviderExtension}
 /// {@canonicalFor bones_api_entity.EntityRepositoryProvider}
 /// {@canonicalFor bones_api_entity.EntityRepository}
@@ -123,7 +122,6 @@
 /// {@canonicalFor bones_api_entity.TransactionOperationUpdate}
 /// {@canonicalFor bones_api_entity.TransactionOperation}
 /// {@canonicalFor bones_api_entity.Transaction}
-/// {@canonicalFor bones_api_entity.TypeInfoEntityExtension}
 /// {@canonicalFor bones_api_entity_annotation.EntityAnnotation}
 /// {@canonicalFor bones_api_entity_annotation.EntityFieldInvalid}
 /// {@canonicalFor bones_api_entity_annotation.EntityField}
@@ -157,6 +155,11 @@
 /// {@canonicalFor bones_api_entity_db_sql.MultipleSQL}
 /// {@canonicalFor bones_api_entity_db_sql.SQLWrapper}
 /// {@canonicalFor bones_api_entity_db_sql.SQL}
+/// {@canonicalFor bones_api_entity_reference.EntitiesFetcher}
+/// {@canonicalFor bones_api_entity_reference.EntityFetcher}
+/// {@canonicalFor bones_api_entity_reference.EntityReferenceBase}
+/// {@canonicalFor bones_api_entity_reference.EntityReferenceList}
+/// {@canonicalFor bones_api_entity_reference.EntityReference}
 /// {@canonicalFor bones_api_entity_sql.DBSQLEntityRepositoryProvider}
 /// {@canonicalFor bones_api_entity_sql.DBSQLEntityRepository}
 /// {@canonicalFor bones_api_error_zone.ErrorZoneExtension}
@@ -165,11 +168,16 @@
 /// {@canonicalFor bones_api_error_zone.createErrorZone}
 /// {@canonicalFor bones_api_error_zone.printToZoneStderr}
 /// {@canonicalFor bones_api_error_zone.printZoneError}
+/// {@canonicalFor bones_api_extension.APIEntityObjectExtension}
+/// {@canonicalFor bones_api_extension.APIEntityTypeExtension}
 /// {@canonicalFor bones_api_extension.ClassReflectionExtension}
+/// {@canonicalFor bones_api_extension.ListOfStringExtension}
 /// {@canonicalFor bones_api_extension.MapGetterExtension}
 /// {@canonicalFor bones_api_extension.MapMultiValueExtension}
 /// {@canonicalFor bones_api_extension.MethodReflectionExtension}
 /// {@canonicalFor bones_api_extension.ReflectionFactoryExtension}
+/// {@canonicalFor bones_api_extension.TypeInfoEntityExtension}
+/// {@canonicalFor bones_api_extension.TypeReflectionEntityExtension}
 /// {@canonicalFor bones_api_initializable.ExecuteInitializedCallback}
 /// {@canonicalFor bones_api_initializable.InitializableListExtension}
 /// {@canonicalFor bones_api_initializable.Initializable}
@@ -217,9 +225,6 @@
 /// {@canonicalFor bones_api_test_utils.APITestConfigDocker}
 /// {@canonicalFor bones_api_test_utils.APITestConfigExtension}
 /// {@canonicalFor bones_api_test_utils.APITestConfig}
-/// {@canonicalFor bones_api_types.APIEntityObjectExtension}
-/// {@canonicalFor bones_api_types.APIEntityTypeExtension}
-/// {@canonicalFor bones_api_types.ListOfStringExtension}
 /// {@canonicalFor bones_api_types.Time}
 /// {@canonicalFor bones_api_utils.FieldNameMapper}
 /// {@canonicalFor bones_api_utils.KeyMapper}
@@ -227,6 +232,7 @@
 /// {@canonicalFor bones_api_utils.tryCallMapped}
 /// {@canonicalFor bones_api_utils.tryCall}
 /// {@canonicalFor bones_api_utils_arguments.Arguments}
+/// {@canonicalFor bones_api_utils_collections.IterableEnumExtension}
 /// {@canonicalFor bones_api_utils_collections.MapAsCacheExtension}
 /// {@canonicalFor bones_api_utils_collections.PositionalFields}
 /// {@canonicalFor bones_api_utils_collections.ValueEquality}
@@ -247,6 +253,7 @@
 /// {@canonicalFor bones_api_utils_httpclient.getURL}
 /// {@canonicalFor bones_api_utils_instance_tracker.InstanceInfoExtractor}
 /// {@canonicalFor bones_api_utils_instance_tracker.InstanceTracker}
+/// {@canonicalFor bones_api_utils_json.JsonEntityCacheExtension}
 /// {@canonicalFor bones_api_utils_json.Json}
 /// {@canonicalFor bones_api_utils_json.ToEncodable}
 /// {@canonicalFor bones_api_utils_timedmap.TimedMap}

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -36,7 +36,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.3.8';
+  static const String VERSION = '1.3.9';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_entity.dart
+++ b/lib/src/bones_api_entity.dart
@@ -3526,7 +3526,8 @@ abstract class EntityRepository<O extends Object> extends EntityAccessor<O>
               parameters: parameters,
               namedParameters: namedParameters,
               transaction: transaction,
-              limit: 1)
+              limit: 1,
+              resolutionRules: resolutionRules)
           .resolveMapped((result) => result.firstOrNull);
 
   @override

--- a/lib/src/bones_api_entity_reference.dart
+++ b/lib/src/bones_api_entity_reference.dart
@@ -353,10 +353,18 @@ class EntityReference<T> extends EntityReferenceBase<T> {
 
       typeName ??= entityReferenceType;
       var id = json['id'];
-      var entityMap = json['entity'];
+      var entity = json['entity'];
 
-      if (entityMap != null) {
-        return EntityReference<T>.fromEntityMap(entityMap,
+      if (entity != null) {
+        var entityMap = entity is Map
+            ? entity
+            : TypeParser.parseMap(entity) ?? <String, dynamic>{};
+
+        var entityMapCast = entityMap is Map<String, dynamic>
+            ? entityMap
+            : entityMap.map((key, value) => MapEntry('$key', value));
+
+        return EntityReference<T>.fromEntityMap(entityMapCast,
                 type: type,
                 typeName: typeName,
                 entityHandler: entityHandler,
@@ -1066,9 +1074,20 @@ class EntityReferenceList<T> extends EntityReferenceBase<T> {
 
       typeName ??= entityReferenceType;
       var ids = json['ids'];
-      var entitiesMaps = json['entities'];
+      var entities = json['entities'];
 
-      if (entitiesMaps != null && entitiesMaps is List<Map<String, dynamic>?>) {
+      if (entities != null && entities is List) {
+        var entitiesMaps = entities is List<Map<String, dynamic>>
+            ? entities
+            : entities.map((e) {
+                var m = e is Map
+                    ? e
+                    : TypeParser.parseMap(e) ?? <String, dynamic>{};
+                return m is Map<String, dynamic>
+                    ? m
+                    : m.map((key, value) => MapEntry('$key', value));
+              }).toList(growable: false);
+
         return EntityReferenceList<T>.fromEntitiesMaps(entitiesMaps,
                 type: type,
                 typeName: typeName,
@@ -1123,7 +1142,8 @@ class EntityReferenceList<T> extends EntityReferenceBase<T> {
             ._autoCast();
       }
 
-      return EntityReferenceList<T>.fromEntitiesMaps([json],
+      return EntityReferenceList<T>.fromEntitiesMaps(
+              <Map<String, dynamic>>[json],
               type: type,
               typeName: typeName,
               entityHandler: entityHandler,

--- a/lib/src/bones_api_extension.dart
+++ b/lib/src/bones_api_extension.dart
@@ -769,6 +769,12 @@ extension APIEntityTypeExtension on Type {
     var self = this;
     return self == EntityReference || self == EntityReferenceList;
   }
+
+  /// Returns this [type] as a [TypeInfo].
+  TypeInfo get typeInfo => TypeInfo.fromType(this);
+
+  /// Parses [value] using [TypeInfo.parse].
+  V? tryParse<V>(Object? value, [V? def]) => typeInfo.parse(value);
 }
 
 /// Extension for entity [Object]s.

--- a/lib/src/bones_api_utils_collections.dart
+++ b/lib/src/bones_api_utils_collections.dart
@@ -300,22 +300,28 @@ Map<K, V>? deepCopyMap<K, V>(Map<K, V>? map) {
 }
 
 /// Returns an [Enum] name.
-String enumToName(Enum enumValue) {
-  var s = enumValue.toString();
-  var idx = s.indexOf('.');
-  var name = s.substring(idx + 1);
-  return name;
-}
+String enumToName(Enum enumValue) => enumValue.name;
 
 /// Returns an [Enum] from [enumValues] that matches [name].
-Enum? enumFromName(String name, Iterable<Enum> enumValues) {
+E? enumFromName<E extends Enum>(String? name, Iterable<E> enumValues) {
+  if (name == null) return null;
+  name = name.trim();
+  if (name.isEmpty) return null;
+
   for (var e in enumValues) {
     var n = enumToName(e);
-    if (n == name) {
+
+    if (equalsIgnoreAsciiCase(n, name)) {
       return e;
     }
   }
+
   return null;
+}
+
+/// Extension on [Iterable] of [Enum].
+extension IterableEnumExtension<E extends Enum> on Iterable<E> {
+  E? parse(String? name) => enumFromName(name, this);
 }
 
 /// Extension that ads cached methods to a [Map].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A Powerful API backend framework for Dart. Comes with a built-in HTTP Server, routes handler, entity handler, SQL translator, and DB adapters.
-version: 1.3.8
+version: 1.3.9
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:

--- a/test/bones_api_types_test.dart
+++ b/test/bones_api_types_test.dart
@@ -65,6 +65,20 @@ void main() {
       expect(t8.hasArguments, isFalse);
     });
 
+    test('Type.tryParse', () async {
+      {
+        var t = DateTime;
+        var v = t.tryParse('2000-01-11');
+        expect(v, equals(DateTime(2000, 1, 11)));
+      }
+
+      {
+        var t = int;
+        var v = t.tryParse('1234');
+        expect(v, equals(1234));
+      }
+    });
+
     test('Time', () async {
       _testTime(Time(1, 2, 3), '01:02:03');
 

--- a/test/bones_api_utils_collection_test.dart
+++ b/test/bones_api_utils_collection_test.dart
@@ -1,0 +1,28 @@
+import 'package:bones_api/bones_api.dart';
+import 'package:test/test.dart';
+
+import 'bones_api_test_entities.dart';
+
+void main() {
+  group('Enum', () {
+    test('enumFromName', () async {
+      expect(enumFromName('admin', RoleType.values), RoleType.admin);
+      expect(enumFromName(' admin ', RoleType.values), RoleType.admin);
+      expect(enumFromName(' Guest ', RoleType.values), RoleType.guest);
+      expect(enumFromName('x', RoleType.values), isNull);
+      expect(enumFromName('', RoleType.values), isNull);
+      expect(enumFromName(null, RoleType.values), isNull);
+    });
+
+    test('enumToName', () async {
+      expect(enumToName(RoleType.admin), equals('admin'));
+      expect(enumToName(RoleType.guest), equals('guest'));
+    });
+
+    test('parse', () async {
+      expect(RoleType.values.parse('admin'), equals(RoleType.admin));
+      expect(RoleType.values.parse(' Guest '), equals(RoleType.guest));
+      expect(RoleType.values.parse(' X '), isNull);
+    });
+  });
+}


### PR DESCRIPTION
- Improved `enumFromName`.
- Added `IterableEnumExtension`.
- Fix `EntityRepository.selectFirstByQuery`:
  - `resolutionRules` wasn't being passed to sub calls.