### PR TITLE
v1.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.3.10
+
+- `EntityReference.fromID`: accepts null ID (works like `asNull`).
+- `Initializable`:
+  - `InitializationChain._isParent`: improve speed of search in the parent tree.
+- Fix update of `Uint8List` fields. 
+
 ## 1.3.9
 
 - Improved `enumFromName`.
@@ -124,7 +131,7 @@
 
 - `bin/bones_api.dart`:
   - Fix parameter `--lib` when respawning for Hot Reload.
-- Added `SQLDialect` for better handling of syntax varaitions.
+- Added `SQLDialect` for better handling of syntax variations.
 - `SQLAdapter`:
   - Moved to `SQLDialect`:
     `sqlElementQuote`, `sqlAcceptsOutputSyntax`, `sqlAcceptsReturningSyntax`, `sqlAcceptsTemporaryTableForReturning`,
@@ -758,7 +765,7 @@
 ## 1.0.22
 
 - `Condition`:
-  - Improved sub-field match.
+  - Improved subfield match.
 - `SQL`:
   - Allow `Condition` with fields that are a relationship table. 
 - `MySQLAdapter`: 
@@ -932,7 +939,7 @@
 
 - CLI Hot Reload fixed:
   - Avoid reload of main Isolate (bones_api CLI),
-    since API is spawned in it's own Isolate.
+    since API is spawned in its own Isolate.
 - `DataEntity`:
   - Added `fieldsNames`.
 - `DataHandlerProvider`:

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -36,7 +36,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.3.9';
+  static const String VERSION = '1.3.10';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_entity.dart
+++ b/lib/src/bones_api_entity.dart
@@ -1301,10 +1301,14 @@ abstract class EntityHandler<O> with FieldsFromMap {
     equals = equalsValuesEnum(value1, value2);
     if (equals != null) return equals;
 
-    var collection1 =
-        TypeParser.isCollectionValue(value1) || value1.isEntityReferenceList;
-    var collection2 =
-        TypeParser.isCollectionValue(value2) || value2.isEntityReferenceList;
+    var collection1 = TypeParser.isCollectionValue(value1) ||
+        value1.isEntityReferenceList ||
+        value1 is Uint8List ||
+        value1 is Int8List;
+    var collection2 = TypeParser.isCollectionValue(value2) ||
+        value2.isEntityReferenceList ||
+        value2 is Uint8List ||
+        value2 is Int8List;
 
     if (collection1 && collection2) {
       return isEqualsDeep(value1, value2, valueEquality: equalsValues);

--- a/lib/src/bones_api_entity_db_relational.dart
+++ b/lib/src/bones_api_entity_db_relational.dart
@@ -265,6 +265,7 @@ class DBRelationalEntityRepository<O extends Object>
           if (fieldValue == null) return null;
 
           var fieldType = entityHandler.getFieldType(o, fieldName)!;
+          if (fieldType.isPrimitiveType) return null;
 
           Object? value = fieldValue;
 

--- a/lib/src/bones_api_entity_reference.dart
+++ b/lib/src/bones_api_entity_reference.dart
@@ -278,7 +278,7 @@ class EntityReference<T> extends EntityReferenceBase<T> {
 
   /// Creates an [EntityReference] with the entity [id] (without a loaded [entity] instance).
   /// See [id] and [isIdSet].
-  EntityReference.fromID(Object id,
+  EntityReference.fromID(Object? id,
       {Type? type,
       String? typeName,
       EntityHandler<T>? entityHandler,
@@ -292,7 +292,7 @@ class EntityReference<T> extends EntityReferenceBase<T> {
   /// Creates an [EntityReference] with the [entity] instance.
   /// The [id] is resolved through the [entity] instance.
   /// See [entity] and [isEntitySet].
-  EntityReference.fromEntity(T entity,
+  EntityReference.fromEntity(T? entity,
       {Type? type,
       String? typeName,
       EntityHandler<T>? entityHandler,
@@ -313,7 +313,7 @@ class EntityReference<T> extends EntityReferenceBase<T> {
             checkGenericType);
 
   /// Creates an [EntityReference] with an [entity] instance from [entityMap].
-  EntityReference.fromEntityMap(Map<String, dynamic> entityMap,
+  EntityReference.fromEntityMap(Map<String, dynamic>? entityMap,
       {Type? type,
       String? typeName,
       EntityHandler<T>? entityHandler,

--- a/lib/src/bones_api_initializable.dart
+++ b/lib/src/bones_api_initializable.dart
@@ -133,11 +133,45 @@ class _InitializationChain {
 
   bool _isParent(Initializable o) {
     var parents = _parents;
-    if (parents == null) return false;
+    if (parents == null || parents.isEmpty) return false;
 
-    if (parents.containsIdentical(o)) return true;
+    var parents2 = <Initializable>{};
 
     for (var p in parents) {
+      if (identical(p, o)) return true;
+
+      parents2.addAll(p._chain.parents);
+    }
+
+    var parents3 = <Initializable>{};
+
+    for (var p in parents2) {
+      if (identical(p, o)) return true;
+
+      parents3.addAll(p._chain.parents);
+    }
+
+    var parents4 = <Initializable>{};
+
+    for (var p in parents3) {
+      if (identical(p, o)) return true;
+
+      parents4.addAll(p._chain.parents);
+    }
+
+    var parents5 = <Initializable>{};
+
+    for (var p in parents4) {
+      if (identical(p, o)) return true;
+
+      parents5.addAll(p._chain.parents);
+    }
+
+    for (var p in parents5) {
+      if (identical(p, o)) return true;
+    }
+
+    for (var p in parents5) {
       if (p._chain._isParent(o)) return true;
     }
 

--- a/lib/src/bones_api_utils_collections.dart
+++ b/lib/src/bones_api_utils_collections.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:async_extension/async_extension.dart';
 import 'package:collection/collection.dart';
 
@@ -235,6 +237,10 @@ List<T>? deepCopyList<T>(List<T>? list) {
 
   if (list is List<String>) {
     return List<String>.from(list) as List<T>;
+  } else if (list is Uint8List) {
+    return Uint8List.fromList(list as Uint8List) as List<T>;
+  } else if (list is Int8List) {
+    return Int8List.fromList(list as Int8List) as List<T>;
   } else if (list is List<int>) {
     return List<int>.from(list) as List<T>;
   } else if (list is List<double>) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A Powerful API backend framework for Dart. Comes with a built-in HTTP Server, routes handler, entity handler, SQL translator, and DB adapters.
-version: 1.3.9
+version: 1.3.10
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:


### PR DESCRIPTION
- `EntityReference.fromID`: accepts null ID (works like `asNull`).
- `Initializable`:
  - `InitializationChain._isParent`: improve speed of search in the parent tree.
- Fix update of `Uint8List` fields.