### PR TITLE
v1.3.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.3.29
+
+- `DBAdapter` and `DBRepositoryAdapter`:
+  - Added `doSelectAll`
+- `DBMemoryObjectAdapter`:
+  - Added support for `doSelectAll`.
+- `APIDBModule`:
+  - Added `dump` route.
+  - JSON output compact: compatible with DB populate source samples.
+- mime: ^1.0.3  
+- path: ^1.8.3
+- yaml_writer: ^1.0.3
+- build_runner: ^2.3.3
+- build_verify: ^3.1.0
+- test: ^1.22.1
+
 ## 1.3.28
 
 - `APIRoot._callZoned`: fix error handling.

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -39,7 +39,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.3.28';
+  static const String VERSION = '1.3.29';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_db_module.dart
+++ b/lib/src/bones_api_db_module.dart
@@ -1,6 +1,11 @@
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:async_extension/async_extension.dart';
 import 'package:bones_api/bones_api.dart';
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart' as logging;
+import 'package:statistics/statistics.dart';
 
 final _log = logging.Logger('APIDBModule');
 
@@ -26,7 +31,6 @@ class APIDBModule extends APIModule {
       var pathParts = request.pathParts;
 
       var idx = pathParts.indexOf('select');
-
       if (idx < 0 || idx == pathParts.length - 1) {
         return APIResponse.notFound();
       }
@@ -40,6 +44,21 @@ class APIDBModule extends APIModule {
           : null;
 
       return select(table, request, eager: eager);
+    });
+
+    routes.add(null, 'dump', (request) {
+      var pathParts = request.pathParts;
+
+      var idx = pathParts.indexOf('dump');
+      if (idx < 0) {
+        return APIResponse.notFound();
+      }
+
+      var pathParams = pathParts.sublist(idx + 1);
+
+      var zip = pathParams.any((p) => equalsIgnoreAsciiCase(p, 'zip'));
+
+      return dump(zip);
     });
   }
 
@@ -96,16 +115,107 @@ class APIDBModule extends APIModule {
 
     var resolutionRules = eager ? EntityResolutionRules(allEager: eager) : null;
 
+    List<Object> list;
+
     if (query.isEmpty) {
       var selectAll =
           await entityRepository.selectAll(resolutionRules: resolutionRules);
-      var list = selectAll.toList();
-      return APIResponse.ok(list, mimeType: 'json');
+      list = selectAll.toList();
     } else {
       var selectByQuery = await entityRepository.selectByQuery(query,
           resolutionRules: resolutionRules);
-      var list = selectByQuery.toList();
-      return APIResponse.ok(list, mimeType: 'json');
+      list = selectByQuery.toList();
     }
+
+    var entitiesJson = _entitiesToJsonMap(list);
+    return APIResponse.ok(entitiesJson, mimeType: 'json');
+  }
+
+  Future<APIResponse<Object>> dump(bool zip) async {
+    if (onlyOnDevelopment && !development) {
+      return APIResponse.error(error: "Unsupported request!");
+    }
+
+    _log.info("APIDBModule[REQUEST]> dump");
+
+    var allRepositories = entityRepositoryProviders.allRepositories();
+
+    var dump = await allRepositories.values
+        .map((repo) => MapEntry(repo.name, repo.selectAll()))
+        .toMapFromEntries()
+        .resolveAllValues();
+
+    var dumpJson = dump.entries
+        .map((e) => MapEntry(e.key, _entitiesToJsonMap(e.value)))
+        .where((e) => e.value.isNotEmpty)
+        .toMapFromEntries();
+
+    if (zip) {
+      var apiName =
+          apiRoot.name.toLowerCase().trim().replaceAll(RegExp(r'\W+'), '_');
+
+      var zipTime = DateTime.now().millisecondsSinceEpoch;
+
+      var zipName = 'db-dump--$apiName--$zipTime';
+
+      var archive = Archive();
+
+      {
+        var dumpJsonBytes = Json.encodeToBytes(dumpJson);
+
+        var archiveFile = ArchiveFile(
+            '$zipName/dump.json', dumpJsonBytes.length, dumpJsonBytes);
+        archive.addFile(archiveFile);
+      }
+
+      var zipEncoder = ZipEncoder();
+
+      var encode = zipEncoder.encode(archive)!;
+      var zipData = encode is Uint8List ? encode : Uint8List.fromList(encode);
+
+      var zipFileName = '$zipName.zip';
+
+      return APIResponse.ok(zipData, mimeType: 'application/zip', headers: {
+        'Content-Disposition': 'attachment; filename="$zipFileName"'
+      });
+    }
+
+    return APIResponse.ok(dumpJson, mimeType: 'json');
+  }
+
+  List<Map<String, dynamic>> _entitiesToJsonMap(Iterable<Object> list) {
+    return list.map((e) => _entityToJsonMap(e)).toList();
+  }
+
+  Map<String, dynamic> _entityToJsonMap(Object e) {
+    var o = Json.toJson(e);
+    return _normalizeEntityJson(o);
+  }
+
+  Map<String, dynamic> _normalizeEntityJson(o) {
+    if (o is Map) {
+      return o.entries.map((e) {
+        var value = _normalizeEntityJsonValue(e.value);
+        return MapEntry<String, dynamic>('${e.key}', value);
+      }).toMapFromEntries();
+    } else {
+      return {};
+    }
+  }
+
+  Object? _normalizeEntityJsonValue(value) {
+    if (value is Map) {
+      if (value.containsKey('EntityReference') && value.containsKey('id')) {
+        value = value['id'];
+      } else if (value.containsKey('EntityReferenceList') &&
+          value.containsKey('ids')) {
+        value = value['ids'];
+      } else if (value.containsKey('id')) {
+        value = value['id'];
+      }
+    } else if (value is List) {
+      value = value.map(_normalizeEntityJsonValue).toList();
+    }
+    return value;
   }
 }

--- a/lib/src/bones_api_entity_db_object_memory.dart
+++ b/lib/src/bones_api_entity_db_object_memory.dart
@@ -586,6 +586,25 @@ class DBMemoryObjectAdapter extends DBAdapter<DBMemoryObjectAdapterContext> {
   }
 
   @override
+  FutureOr<List<R>> doSelectAll<R>(
+          TransactionOperation op, String entityName, String table,
+          {PreFinishDBOperation<Iterable<Map<String, dynamic>>, List<R>>?
+              preFinish}) =>
+      executeTransactionOperation<List<R>>(
+          op,
+          (conn) => _doSelectAllImpl<R>(table, entityName)
+              .resolveMapped((res) => _finishOperation(op, res, preFinish)));
+
+  FutureOr<List<Map<String, dynamic>>> _doSelectAllImpl<R>(
+      String table, String entityName) {
+    var map = _getTableMap(table, false);
+    if (map == null) return [];
+
+    var entries = map.values.toList();
+    return entries;
+  }
+
+  @override
   FutureOr<R> doDelete<R>(TransactionOperation op, String entityName,
           String table, EntityMatcher matcher,
           {Object? parameters,

--- a/lib/src/bones_api_entity_db_sql.dart
+++ b/lib/src/bones_api_entity_db_sql.dart
@@ -1729,6 +1729,18 @@ abstract class DBSQLAdapter<C extends Object> extends DBRelationalAdapter<C>
   }
 
   @override
+  FutureOr<List<R>> doSelectAll<R>(
+      TransactionOperation op, String entityName, String table,
+      {PreFinishDBOperation<Iterable<Map<String, dynamic>>, List<R>>?
+          preFinish}) {
+    return generateSelectSQL(op.transaction, entityName, table, ConditionANY())
+        .resolveMapped((sql) {
+      return selectSQL(op, entityName, table, sql)
+          .resolveMapped((r) => _finishOperation(op, r, preFinish));
+    });
+  }
+
+  @override
   FutureOr<R> doSelect<R>(TransactionOperation op, String entityName,
       String table, EntityMatcher matcher,
       {Object? parameters,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A Powerful API backend framework for Dart. Comes with a built-in HTTP Server, routes handler, entity handler, SQL translator, and DB adapters.
-version: 1.3.28
+version: 1.3.29
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:
@@ -24,16 +24,16 @@ dependencies:
   hotreloader: ^3.0.5
   logging: ^1.1.0
   collection: ^1.17.0
-  mime: ^1.0.0
+  mime: ^1.0.3
   postgres: ^2.5.2
   mysql1: ^0.20.0
   yaml: ^3.1.1
-  yaml_writer: ^1.0.2
+  yaml_writer: ^1.0.3
   mercury_client: ^2.1.7
   project_template: ^1.0.2
   resource_portable: ^3.0.0
   crypto: ^3.0.2
-  path: ^1.8.1
+  path: ^1.8.3
   swiss_knife: ^3.1.2
   map_history: ^1.0.3
   docker_commander: ^2.0.15
@@ -43,9 +43,9 @@ dependencies:
 
 dev_dependencies:
   lints: ^2.0.1
-  build_runner: ^2.3.2
-  build_verify: ^3.0.0
-  test: ^1.22.0
+  build_runner: ^2.3.3
+  build_verify: ^3.1.0
+  test: ^1.22.1
   pubspec: ^2.3.0
   dependency_validator: ^3.2.2
   coverage: ^1.6.1


### PR DESCRIPTION
- `DBAdapter` and `DBRepositoryAdapter`:
  - Added `doSelectAll`
- `DBMemoryObjectAdapter`:
  - Added support for `doSelectAll`.
- `APIDBModule`:
  - Added `dump` route.
  - JSON output compact: compatible with DB populate source samples.
- mime: ^1.0.3
- path: ^1.8.3
- yaml_writer: ^1.0.3
- build_runner: ^2.3.3
- build_verify: ^3.1.0
- test: ^1.22.1