### PR TITLE
v1.3.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.37
+
+- `TransactionEntityProvider`:
+  - Fix `getEntityByID` implementation: wasn't passing parameter `resolutionRules` to sub-calls.
+- reflection_factory: ^1.2.25
+
 ## 1.3.36
 
 - `DBRelationalEntityRepository`:

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -39,7 +39,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.3.36';
+  static const String VERSION = '1.3.37';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_entity.dart
+++ b/lib/src/bones_api_entity.dart
@@ -4705,7 +4705,8 @@ class TransactionEntityProvider implements EntityProvider {
           entityRepositoryProvider.getEntityRepository(type: t);
       if (entityRepository == null) return null;
 
-      var sel = entityRepository.selectByID(id);
+      var sel =
+          entityRepository.selectByID(id, resolutionRules: resolutionRules);
       return sel.resolveMapped((o) => o as O?);
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A Powerful API backend framework for Dart. Comes with a built-in HTTP Server, routes handler, entity handler, SQL translator, and DB adapters.
-version: 1.3.36
+version: 1.3.37
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:
@@ -17,7 +17,7 @@ dependencies:
   async_extension: ^1.0.12
   dart_spawner: ^1.0.6
   args: ^2.3.2
-  reflection_factory: ^1.2.22
+  reflection_factory: ^1.2.25
   meta: ^1.7.0
   statistics: ^1.0.24
   petitparser: ^5.1.0

--- a/test/bones_api_test.reflection.g.dart
+++ b/test/bones_api_test.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/1.2.22
+// BUILDER: reflection_factory/1.2.25
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('1.2.22');
+  static final Version _version = Version.parse('1.2.25');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/test/bones_api_test_entities.reflection.g.dart
+++ b/test/bones_api_test_entities.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/1.2.22
+// BUILDER: reflection_factory/1.2.25
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('1.2.22');
+  static final Version _version = Version.parse('1.2.25');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/test/bones_api_test_modules.reflection.g.dart
+++ b/test/bones_api_test_modules.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/1.2.22
+// BUILDER: reflection_factory/1.2.25
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('1.2.22');
+  static final Version _version = Version.parse('1.2.25');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/test/bones_api_test_utils_test.reflection.g.dart
+++ b/test/bones_api_test_utils_test.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/1.2.22
+// BUILDER: reflection_factory/1.2.25
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('1.2.22');
+  static final Version _version = Version.parse('1.2.25');
 
   Version get reflectionFactoryVersion => _version;
 


### PR DESCRIPTION
- `TransactionEntityProvider`:
  - Fix `getEntityByID` implementation: wasn't passing parameter `resolutionRules` to sub-calls.
- reflection_factory: ^1.2.25