### PR TITLE
v1.3.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.3.39
+
+- `APIRoot._callZoned`:
+  - Better handling of errors: throwing with `StackTrace`. 
+- `EntityResolutionRules`:
+  - Added `isEagerEntityTypeInfo` and `isLazyEntityTypeInfo`.
+- `DBEntityRepository`:
+  - Optimize: `resolveEntities` and `_resolveEntitiesSubEntities`.
+- `APIServer`:
+  - `_sendAPIResponse`: better handling of error response.
+- `Time.parse`:
+  - Fix issue parsing input `String` as bytes.  
+- coverage: ^1.6.3
+
 ## 1.3.38
 
 - `SQLGenerator`:

--- a/lib/src/bones_api_entity.dart
+++ b/lib/src/bones_api_entity.dart
@@ -258,6 +258,18 @@ class EntityResolutionRules {
     return def;
   }
 
+  /// Alias to [isEagerEntityType] with a [TypeInfo] parameter.
+  bool isEagerEntityTypeInfo(TypeInfo entityTypeInfo, [bool def = false]) {
+    var entityType = entityTypeInfo.entityType;
+    return entityType != null ? isEagerEntityType(entityType, def) : false;
+  }
+
+  /// Alias to [isLazyEntityType] with a [TypeInfo] parameter.
+  bool isLazyEntityTypeInfo(TypeInfo entityTypeInfo, [bool def = false]) {
+    var entityType = entityTypeInfo.entityType;
+    return entityType != null ? isLazyEntityType(entityType, def) : false;
+  }
+
   @override
   String toString() {
     return 'EntityResolutionRules{allowEntityFetch: $allowEntityFetch, allowReadFile: $allowReadFile, lazyEntityTypes: $lazyEntityTypes, eagerEntityTypes: $eagerEntityTypes}';

--- a/lib/src/bones_api_server.dart
+++ b/lib/src/bones_api_server.dart
@@ -1082,6 +1082,8 @@ class APIServer {
 
           var retError = resolveBody(errorContent, apiResponse);
 
+          headers[HttpHeaders.contentTypeHeader] ??= 'text/plain';
+
           return retError.resolveMapped((error) {
             return Response.internalServerError(body: error, headers: headers);
           });

--- a/lib/src/bones_api_types.dart
+++ b/lib/src/bones_api_types.dart
@@ -177,12 +177,8 @@ class Time implements Comparable<Time> {
 
     if (idx1 != 2 || (idx2 > 0 && idx2 < idx1)) {
       if (allowFromBytes) {
-        try {
-          var bs = dart_convert.latin1.encode(s);
-          return Time.fromBytes(bs, allowParseString: false);
-        } catch (_) {
-          throw FormatException('Invalid string or bytes format: $s');
-        }
+        var bs = _string2bytes(s);
+        return Time.fromBytes(bs, allowParseString: false);
       }
 
       throw FormatException('Invalid `Time` format: $s');
@@ -221,6 +217,18 @@ class Time implements Comparable<Time> {
     var sec = int.parse(secStr);
 
     return Time(h, m, sec, ms, mic);
+  }
+
+  static Uint8List _string2bytes(String s) {
+    try {
+      return dart_convert.utf8.encode(s).asUint8List;
+    } catch (_) {
+      try {
+        return dart_convert.latin1.encode(s);
+      } catch (_) {
+        return s.codeUnits.asUint8List;
+      }
+    }
   }
 
   static Time? from(Object? o) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A Powerful API backend framework for Dart. Comes with a built-in HTTP Server, routes handler, entity handler, SQL translator, and DB adapters.
-version: 1.3.38
+version: 1.3.39
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:
@@ -49,7 +49,7 @@ dev_dependencies:
   test: ^1.22.2
   pubspec: ^2.3.0
   dependency_validator: ^3.2.2
-  coverage: ^1.6.2
+  coverage: ^1.6.3
 
 #dependency_overrides:
 #  async_events:


### PR DESCRIPTION
- `APIRoot._callZoned`:
  - Better handling of errors: throwing with `StackTrace`.
- `EntityResolutionRules`:
  - Added `isEagerEntityTypeInfo` and `isLazyEntityTypeInfo`.
- `DBEntityRepository`:
  - Optimize: `resolveEntities` and `_resolveEntitiesSubEntities`.
- `APIServer`:
  - `_sendAPIResponse`: better handling of error response.
- `Time.parse`:
  - Fix issue parsing input `String` as bytes.
- coverage: ^1.6.3