### PR TITLE
v1.3.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 1.3.42
+
+- New `APIEntityAccessRules`, `EntityAccessRules`, `EntityAccessRulesCached` and `EntityAccessRulesContext`:
+- Renamed `MergeEntityResolutionRulesError` to `MergeEntityRulesError`.
+- Renamed `ValidateEntityResolutionRulesError` to `ValidateEntityRulesError`.
+- `EntityAccessRules` and `EntityResolutionRules` now extends `EntityRules`.
+- `APIRouteHandler`:
+  - Added `entityAccessRules`.
+  - Optimize `entityResolutionRules`.
+- `APIResponse`:
+  - Added field `apiRequest`.
+- `EntityReferenceBase`:
+  - `toJson`: added parameter `jsonEncoder`.
+    - Fixes some to JSON issues, preserving the parent `jsonEncoder`. 
+- `Json`:
+  - `toJson`: expose parameter `toEncodableProvider`.
+- `APIServer`:
+  - `resolveBody`:
+    - When converting to JSON respect the `EntityAccessRules` of the context.
+- test: ^1.23.1
+
 ## 1.3.41
 
 - `EntityResolutionRules`:

--- a/lib/src/bones_api_entity_reference.dart
+++ b/lib/src/bones_api_entity_reference.dart
@@ -263,7 +263,7 @@ abstract class EntityReferenceBase<T> {
   }
 
   /// Encodes to JSON.
-  Map<String, dynamic>? toJson();
+  Map<String, dynamic>? toJson([JsonEncoder? jsonEncoder]);
 
   Map<String, dynamic>? _entityToJsonDefault(Object? entity) {
     if (entity == null) return null;
@@ -679,9 +679,13 @@ class EntityReference<T> extends EntityReferenceBase<T> {
   DateTime? get entityTime => _entityTime;
 
   /// Returns [entity] as a JSON [Map].
-  Map<String, dynamic>? entityToJson() {
+  Map<String, dynamic>? entityToJson([JsonEncoder? jsonEncoder]) {
     var entity = this.entity;
     if (entity == null) return null;
+
+    if (jsonEncoder != null) {
+      return jsonEncoder.toJson(entity);
+    }
 
     var entityHandler = this.entityHandler;
 
@@ -712,7 +716,7 @@ class EntityReference<T> extends EntityReferenceBase<T> {
   /// - `id`: the entity ID (if [isIdSet]).
   /// - `entity`: the entity as JSON (if [isEntitySet]). See [entityToJson].
   @override
-  Map<String, dynamic>? toJson() {
+  Map<String, dynamic>? toJson([JsonEncoder? jsonEncoder]) {
     if (isNull) return null;
 
     if (isEntitySet) {
@@ -720,7 +724,7 @@ class EntityReference<T> extends EntityReferenceBase<T> {
       return <String, dynamic>{
         'EntityReference': typeName,
         if (id != null) 'id': id,
-        'entity': entityToJson(),
+        'entity': entityToJson(jsonEncoder),
       };
     } else if (isIdSet) {
       var id = this.id!;
@@ -1573,9 +1577,18 @@ class EntityReferenceList<T> extends EntityReferenceBase<T> {
   DateTime? get entitiesTime => _entitiesTime;
 
   /// Returns [entities] as a JSON [List] of entities [Map].
-  List<Map<String, dynamic>?>? entitiesToJson() {
+  List<Map<String, dynamic>?>? entitiesToJson([JsonEncoder? jsonEncoder]) {
     var entities = this.entities;
     if (entities == null) return null;
+
+    if (jsonEncoder != null) {
+      var jsonList = entities
+          .map((e) => e == null
+              ? null
+              : (jsonEncoder.toJson(e) as Map<String, dynamic>?))
+          .toList();
+      return jsonList;
+    }
 
     var entityHandler = this.entityHandler;
 
@@ -1613,7 +1626,7 @@ class EntityReferenceList<T> extends EntityReferenceBase<T> {
   /// - `ids`: the entities IDs (if [isIDsSet]).
   /// - `entities`: the entities as JSON (if [isEntitiesSet]). See [entitiesToJson].
   @override
-  Map<String, dynamic>? toJson() {
+  Map<String, dynamic>? toJson([JsonEncoder? jsonEncoder]) {
     if (isNull) {
       return null;
     }
@@ -1628,7 +1641,7 @@ class EntityReferenceList<T> extends EntityReferenceBase<T> {
       return <String, dynamic>{
         'EntityReferenceList': typeName,
         if (hasAnyID) 'ids': ids,
-        if (hasAnyEntity) 'entities': entitiesToJson(),
+        if (hasAnyEntity) 'entities': entitiesToJson(jsonEncoder),
       };
     } else if (isIDsSet) {
       var ids = this.ids!;

--- a/lib/src/bones_api_module.dart
+++ b/lib/src/bones_api_module.dart
@@ -429,12 +429,20 @@ class APIRouteBuilder<M extends APIModule> {
       [APIRequestMethod? requestMethod]) {
     var returnsAPIResponse = apiMethod.returnsAPIResponse;
     var receivesAPIRequest = apiMethod.receivesAPIRequest;
-    var rules = apiMethod.annotations.whereType<APIRouteRule>().toList();
 
-    if (rules.isEmpty) {
-      rules = apiMethod.classReflection.classAnnotations
-          .whereType<APIRouteRule>()
-          .toList();
+    var methodRules = apiMethod.annotations.whereType<APIRouteRule>().toList();
+    var classRules = apiMethod.classReflection.classAnnotations
+        .whereType<APIRouteRule>()
+        .toList();
+
+    List<APIRouteRule> rules;
+    if (methodRules.isEmpty) {
+      rules = classRules;
+    } else {
+      rules = [
+        ...methodRules,
+        ...classRules.where((r) => r.mandatoryClassRule),
+      ];
     }
 
     if (returnsAPIResponse && receivesAPIRequest) {

--- a/lib/src/bones_api_security.dart
+++ b/lib/src/bones_api_security.dart
@@ -606,7 +606,9 @@ abstract class APISecurity {
 
 /// A route rule.
 abstract class APIRouteRule {
-  const APIRouteRule();
+  final bool mandatoryClassRule;
+
+  const APIRouteRule({this.mandatoryClassRule = false});
 
   /// Returns `true` if the [request] is valid by this rule.
   bool validate(APIRequest request);
@@ -740,6 +742,26 @@ class APIEntityResolutionRules extends APIRouteRule {
   @override
   Map<String, Object> toJson() =>
       <String, Object>{'resolutionRules': resolutionRules.toJson()};
+}
+
+/// Defines an [EntityAccessRules] for a route.
+class APIEntityAccessRules extends APIRouteRule {
+  final EntityAccessRules accessRules;
+
+  const APIEntityAccessRules(this.accessRules)
+      : super(mandatoryClassRule: true);
+
+  @override
+  bool validate(APIRequest request) => true;
+
+  @override
+  String toString() {
+    return 'APIEntityAccessRules@$accessRules';
+  }
+
+  @override
+  Map<String, Object> toJson() =>
+      <String, Object>{'accessRules': accessRules.toJson()};
 }
 
 class SecureRandom implements Random {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A Powerful API backend framework for Dart. Comes with a built-in HTTP Server, routes handler, entity handler, SQL translator, and DB adapters.
-version: 1.3.41
+version: 1.3.42
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:
@@ -46,7 +46,7 @@ dev_dependencies:
   lints: ^2.0.1
   build_runner: ^2.3.3
   build_verify: ^3.1.0
-  test: ^1.22.2
+  test: ^1.23.1
   pubspec: ^2.3.0
   dependency_validator: ^3.2.2
   coverage: ^1.6.3

--- a/test/bones_api_module_test.dart
+++ b/test/bones_api_module_test.dart
@@ -43,8 +43,10 @@ void main() {
         'echoUser',
         'geDynamicAsync',
         'geDynamicAsync2',
-        'getContext',
+        'getContextEntityResolutionRules',
         'getDynamic',
+        'getRequestEntityAccessRules',
+        'getRequestEntityResolutionRules',
         'getUser',
         'getUserAsync'
       ];
@@ -231,11 +233,36 @@ void main() {
           ]));
 
       expect(
-          (await apiRoot.call(APIRequest.post('/user/getContext'))).payload,
+          (await apiRoot.call(
+                  APIRequest.post('/user/getContextEntityResolutionRules')))
+              .payload,
           equals({
-            'context': {
+            'context.resolutionRules': {
               'allowEntityFetch': true,
               'eagerEntityTypes': ['User']
+            }
+          }));
+
+      expect(
+          (await apiRoot.call(
+                  APIRequest.post('/user/getRequestEntityResolutionRules')))
+              .payload,
+          equals({
+            'resolutionRules': {
+              'allowEntityFetch': true,
+              'eagerEntityTypes': ['User']
+            }
+          }));
+
+      expect(
+          (await apiRoot
+                  .call(APIRequest.post('/user/getRequestEntityAccessRules')))
+              .payload,
+          equals({
+            'accessRules': {
+              'ruleType': 'block',
+              'entityType': 'User',
+              'entityFields': ['email']
             }
           }));
 

--- a/test/bones_api_test_modules.dart
+++ b/test/bones_api_test_modules.dart
@@ -24,6 +24,11 @@ class AboutModule extends APIModule {
   APIResponse<String> about() => APIResponse.ok('About...');
 }
 
+bool _blockUserEmailCondition(EntityAccessRulesContext? c) =>
+    c?.objectAs<User>()?.email.contains('secret') ?? false;
+
+@APIEntityAccessRules(EntityAccessRules.blockFields(User, ['email'],
+    condition: _blockUserEmailCondition))
 @APIEntityResolutionRules(EntityResolutionRules.fetchEager([User]))
 @EnableReflection()
 class UserModule extends APIModule {
@@ -64,11 +69,24 @@ class UserModule extends APIModule {
   Future<dynamic> geDynamicAsync2(int id) async => APIResponse.ok(
       User('joe@email.com', 'pass123', Address('SC', 'NY', '', 123), []));
 
-  Future<APIResponse<Map>> getContext() async {
+  Future<APIResponse<Map>> getContextEntityResolutionRules() async {
     var cotextProvider = EntityRulesResolver.cotextProviders.first;
-
     var resolutionRules = cotextProvider.getContextEntityResolutionRules();
+    return APIResponse.ok(
+        {'context.resolutionRules': resolutionRules?.toJson()});
+  }
 
-    return APIResponse.ok({'context': resolutionRules?.toJson()});
+  Future<APIResponse<Map>> getRequestEntityResolutionRules(
+      APIRequest request) async {
+    var routeHandler = request.routeHandler;
+    var resolutionRules = routeHandler?.entityResolutionRules;
+    return APIResponse.ok({'resolutionRules': resolutionRules?.toJson()});
+  }
+
+  Future<APIResponse<Map>> getRequestEntityAccessRules(
+      APIRequest request) async {
+    var routeHandler = request.routeHandler;
+    var accessRules = routeHandler?.entityAccessRules;
+    return APIResponse.ok({'accessRules': accessRules?.toJson()});
   }
 }

--- a/test/bones_api_test_modules.reflection.g.dart
+++ b/test/bones_api_test_modules.reflection.g.dart
@@ -900,6 +900,8 @@ class UserModule$reflection extends ClassReflection<UserModule>
   }
 
   static const List<Object> _classAnnotations = [
+    APIEntityAccessRules(EntityAccessRules.blockFields(User, ['email'],
+        condition: _blockUserEmailCondition)),
     APIEntityResolutionRules(EntityResolutionRules.fetchEager([User]))
   ];
 
@@ -1198,8 +1200,10 @@ class UserModule$reflection extends ClassReflection<UserModule>
         'executeInitialized',
         'geDynamicAsync',
         'geDynamicAsync2',
-        'getContext',
+        'getContextEntityResolutionRules',
         'getDynamic',
+        'getRequestEntityAccessRules',
+        'getRequestEntityResolutionRules',
         'getRouteHandler',
         'getRouteHandlerByRequest',
         'getRoutesHandlersNames',
@@ -1432,12 +1436,12 @@ class UserModule$reflection extends ClassReflection<UserModule>
             null,
             null,
             null);
-      case 'getcontext':
+      case 'getcontextentityresolutionrules':
         return MethodReflection<UserModule,
                 Future<APIResponse<Map<dynamic, dynamic>>>>(
             this,
             UserModule,
-            'getContext',
+            'getContextEntityResolutionRules',
             __TR<Future<APIResponse<Map<dynamic, dynamic>>>>(Future, <__TR>[
               __TR<APIResponse<Map<dynamic, dynamic>>>(APIResponse, <__TR>[
                 __TR<Map<dynamic, dynamic>>(
@@ -1445,10 +1449,54 @@ class UserModule$reflection extends ClassReflection<UserModule>
               ])
             ]),
             false,
-            (o) => o!.getContext,
+            (o) => o!.getContextEntityResolutionRules,
             obj,
             false,
             null,
+            null,
+            null,
+            null);
+      case 'getrequestentityresolutionrules':
+        return MethodReflection<UserModule,
+                Future<APIResponse<Map<dynamic, dynamic>>>>(
+            this,
+            UserModule,
+            'getRequestEntityResolutionRules',
+            __TR<Future<APIResponse<Map<dynamic, dynamic>>>>(Future, <__TR>[
+              __TR<APIResponse<Map<dynamic, dynamic>>>(APIResponse, <__TR>[
+                __TR<Map<dynamic, dynamic>>(
+                    Map, <__TR>[__TR.tDynamic, __TR.tDynamic])
+              ])
+            ]),
+            false,
+            (o) => o!.getRequestEntityResolutionRules,
+            obj,
+            false,
+            const <__PR>[
+              __PR(__TR<APIRequest>(APIRequest), 'request', false, true)
+            ],
+            null,
+            null,
+            null);
+      case 'getrequestentityaccessrules':
+        return MethodReflection<UserModule,
+                Future<APIResponse<Map<dynamic, dynamic>>>>(
+            this,
+            UserModule,
+            'getRequestEntityAccessRules',
+            __TR<Future<APIResponse<Map<dynamic, dynamic>>>>(Future, <__TR>[
+              __TR<APIResponse<Map<dynamic, dynamic>>>(APIResponse, <__TR>[
+                __TR<Map<dynamic, dynamic>>(
+                    Map, <__TR>[__TR.tDynamic, __TR.tDynamic])
+              ])
+            ]),
+            false,
+            (o) => o!.getRequestEntityAccessRules,
+            obj,
+            false,
+            const <__PR>[
+              __PR(__TR<APIRequest>(APIRequest), 'request', false, true)
+            ],
             null,
             null,
             null);

--- a/test/bones_api_utils_json_test.dart
+++ b/test/bones_api_utils_json_test.dart
@@ -69,12 +69,38 @@ void main() {
           Json.toJson(EntityReference.fromEntity(Role(RoleType.admin))),
           equals({
             'EntityReference': 'Role',
+            'entity': {
+              'enabled': true,
+              'id': null,
+              'type': 'admin',
+              'value': null
+            }
+          }));
+
+      expect(
+          Json.toJson(EntityReference.fromEntity(Role(RoleType.admin)),
+              removeNullFields: true),
+          equals({
+            'EntityReference': 'Role',
             'entity': {'enabled': true, 'type': 'admin'}
           }));
 
       expect(
           Json.toJson(EntityReferenceList.fromEntities(
               [Role(RoleType.admin), Role(RoleType.guest)])),
+          equals({
+            'EntityReferenceList': 'Role',
+            'entities': [
+              {'enabled': true, 'id': null, 'type': 'admin', 'value': null},
+              {'enabled': true, 'id': null, 'type': 'guest', 'value': null}
+            ]
+          }));
+
+      expect(
+          Json.toJson(
+              EntityReferenceList.fromEntities(
+                  [Role(RoleType.admin), Role(RoleType.guest)]),
+              removeNullFields: true),
           equals({
             'EntityReferenceList': 'Role',
             'entities': [
@@ -89,6 +115,23 @@ void main() {
             'value': EntityReferenceList.fromEntities(
                 [Role(RoleType.admin), Role(RoleType.guest)])
           }),
+          equals({
+            'name': 'a',
+            'value': {
+              'EntityReferenceList': 'Role',
+              'entities': [
+                {'enabled': true, 'id': null, 'type': 'admin', 'value': null},
+                {'enabled': true, 'id': null, 'type': 'guest', 'value': null}
+              ]
+            }
+          }));
+
+      expect(
+          Json.toJson({
+            'name': 'a',
+            'value': EntityReferenceList.fromEntities(
+                [Role(RoleType.admin), Role(RoleType.guest)])
+          }, removeNullFields: true),
           equals({
             'name': 'a',
             'value': {
@@ -109,6 +152,39 @@ void main() {
               EntityReferenceList.fromEntities([Role(RoleType.unknown)])
             ]
           }),
+          equals({
+            'name': 'a',
+            'values': [
+              {
+                'EntityReferenceList': 'Role',
+                'entities': [
+                  {'enabled': true, 'id': null, 'type': 'admin', 'value': null},
+                  {'enabled': true, 'id': null, 'type': 'guest', 'value': null}
+                ]
+              },
+              {
+                'EntityReferenceList': 'Role',
+                'entities': [
+                  {
+                    'enabled': true,
+                    'id': null,
+                    'type': 'unknown',
+                    'value': null
+                  }
+                ]
+              }
+            ]
+          }));
+
+      expect(
+          Json.toJson({
+            'name': 'a',
+            'values': [
+              EntityReferenceList.fromEntities(
+                  [Role(RoleType.admin), Role(RoleType.guest)]),
+              EntityReferenceList.fromEntities([Role(RoleType.unknown)])
+            ]
+          }, removeNullFields: true),
           equals({
             'name': 'a',
             'values': [


### PR DESCRIPTION
- New `APIEntityAccessRules`, `EntityAccessRules`, `EntityAccessRulesCached` and `EntityAccessRulesContext`:
- Renamed `MergeEntityResolutionRulesError` to `MergeEntityRulesError`.
- Renamed `ValidateEntityResolutionRulesError` to `ValidateEntityRulesError`.
- `EntityAccessRules` and `EntityResolutionRules` now extends `EntityRules`.
- `APIRouteHandler`:
  - Added `entityAccessRules`.
  - Optimize `entityResolutionRules`.
- `APIResponse`:
  - Added field `apiRequest`.
- `EntityReferenceBase`:
  - `toJson`: added parameter `jsonEncoder`. - Fixes some to JSON issues, preserving the parent `jsonEncoder`.
- `Json`:
  - `toJson`: expose parameter `toEncodableProvider`.
- `APIServer`:
  - `resolveBody`: - When converting to JSON respect the `EntityAccessRules` of the context.
- test: ^1.23.1