### PR TITLE
v1.3.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.3.56
+
+- `EntityReference`:
+  - `disposeEntities`: force `_resolveID` before dispose.
+- `EntityReferenceList`:
+  - `disposeEntities`: force `_resolveIDs` before dispose.
+- `APIRouteBuilder`:
+  - `_resolveValueType`: resulve `List`, `Set`, `Map` generic types. 
+
 ## 1.3.55
 
 - `APIResponseStatus`

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -40,7 +40,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.3.55';
+  static const String VERSION = '1.3.56';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_entity_reference.dart
+++ b/lib/src/bones_api_entity_reference.dart
@@ -901,6 +901,7 @@ class EntityReference<T> extends EntityReferenceBase<T> {
   /// Disposes the current loaded [entity] instance and returns it.
   /// Id [id] is defined it will keep it.
   T? disposeEntity() {
+    _resolveID();
     var prev = entity;
     _entity = null;
     _entityTime = null;
@@ -1900,6 +1901,7 @@ class EntityReferenceList<T> extends EntityReferenceBase<T> {
   /// Disposes the current loaded [entity] instance and returns it.
   /// Id [id] is defined it will keep it.
   List<T?>? disposeEntities() {
+    _resolveIDs();
     var prev = entities;
     _entities = null;
     _entitiesTime = null;

--- a/lib/src/bones_api_extension.dart
+++ b/lib/src/bones_api_extension.dart
@@ -427,6 +427,9 @@ extension TypeInfoEntityExtension<T> on TypeInfo<T> {
   /// The argument at index `0` (in [arguments]).
   TypeInfo? get arguments0 => argumentType(0);
 
+  /// The argument at index `1` (in [arguments]).
+  TypeInfo? get arguments1 => argumentType(1);
+
   /// Returns `true` if [isListEntity] OR [isEntityReferenceListType].
   bool get isListEntityOrReference => isListEntity || isEntityReferenceListType;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A Powerful API backend framework for Dart. Comes with a built-in HTTP Server, routes handler, entity handler, SQL translator, and DB adapters.
-version: 1.3.55
+version: 1.3.56
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:


### PR DESCRIPTION
- `EntityReference`:
  - `disposeEntities`: force `_resolveID` before dispose.
- `EntityReferenceList`:
  - `disposeEntities`: force `_resolveIDs` before dispose.
- `APIRouteBuilder`:
  - `_resolveValueType`: resulve `List`, `Set`, `Map` generic types.