### PR TITLE
v1.3.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.3.57
+
+- New `DBObjectAdapter`:
+  - Base class for `DBObjectMemoryAdapter` and `DBObjectDirectoryAdapter`.
+- New `DBAdapterRegister`:
+  - handles `DBAdapter` registration, avoiding repetitive static code in
+    `DBSQLAdapter`, `DBObjectAdapter` and `DBRelationalAdapter`.
+- `EntityHandler`
+  - Added `equalsValuesEntityMap`.
+  - Added `getEntityIDFrom`.
+  - `equalsValuesEntity` now also using `equalsValuesEntityMap`.
+    - This fixes an issue for `DBSQLMemoryAdapter`. 
+
 ## 1.3.56
 
 - `EntityReference`:

--- a/bones_api.iml
+++ b/bones_api.iml
@@ -10,7 +10,7 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Dart Packages" level="project" />
+    <orderEntry type="library" name="Dart SDK" level="project" />
   </component>
 </module>

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -40,7 +40,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.3.56';
+  static const String VERSION = '1.3.57';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_entity.dart
+++ b/lib/src/bones_api_entity.dart
@@ -1432,7 +1432,32 @@ abstract class EntityHandler<O> with FieldsFromMap, EntityRulesResolver {
       return id1 == id2;
     }
 
-    return false;
+    return equalsValuesEntityMap(value1, value2, entityHandler: entityHandler);
+  }
+
+  static bool equalsValuesEntityMap(Object value1, Object value2,
+      {EntityHandler? entityHandler}) {
+    if (value1 is Map && value2 is Map) {
+      return isEqualsDeep(value1, value2);
+    }
+
+    var id1 = getEntityIDFrom(value1, entityHandler: entityHandler);
+    var id2 = getEntityIDFrom(value2, entityHandler: entityHandler);
+
+    return id1 == id2;
+  }
+
+  static Object? getEntityIDFrom(Object o, {EntityHandler? entityHandler}) {
+    if (o is num || o is String) {
+      return o;
+    } else if (o is Map) {
+      return o.getIgnoreCase('id');
+    } else if (entityHandler != null && isValidEntityType(o.runtimeType)) {
+      var objEntityHandler = entityHandler.getEntityHandler(obj: o);
+      return objEntityHandler?.getID(o);
+    }
+
+    return null;
   }
 
   static bool? equalsEntityReferenceBase(Object value1, Object value2) {

--- a/lib/src/bones_api_entity_db_mysql.dart
+++ b/lib/src/bones_api_entity_db_mysql.dart
@@ -72,11 +72,12 @@ class DBMySQLAdapter extends DBSQLAdapter<DBMySqlConnectionWrapper>
       int? port = 3306,
       int minConnections = 1,
       int maxConnections = 3,
-      bool generateTables = false,
-      Object? populateTables,
-      Object? populateSource,
-      EntityRepositoryProvider? parentRepositoryProvider,
-      String? workingPath})
+      super.generateTables,
+      super.populateTables,
+      super.populateSource,
+      super.parentRepositoryProvider,
+      super.workingPath,
+      super.logSQL})
       : host = host ?? 'localhost',
         port = port ?? 3306,
         _password = (password != null && password is! PasswordProvider
@@ -98,11 +99,6 @@ class DBMySQLAdapter extends DBSQLAdapter<DBMySqlConnectionWrapper>
               transactions: true,
               transactionAbort: true,
               tableSQL: true),
-          generateTables: generateTables,
-          populateTables: populateTables,
-          populateSource: populateSource,
-          parentRepositoryProvider: parentRepositoryProvider,
-          workingPath: workingPath,
         ) {
     boot();
 
@@ -155,6 +151,8 @@ class DBMySQLAdapter extends DBSQLAdapter<DBMySqlConnectionWrapper>
     if (database == null) throw ArgumentError.notNull('database');
     if (username == null) throw ArgumentError.notNull('username');
 
+    var logSql = DBSQLAdapter.parseConfigLogSQL(config) ?? false;
+
     return DBMySQLAdapter(
       database,
       username,
@@ -168,6 +166,7 @@ class DBMySQLAdapter extends DBSQLAdapter<DBMySqlConnectionWrapper>
       populateSource: populateSource,
       parentRepositoryProvider: parentRepositoryProvider,
       workingPath: workingPath,
+      logSQL: logSql,
     );
   }
 

--- a/lib/src/bones_api_entity_db_object.dart
+++ b/lib/src/bones_api_entity_db_object.dart
@@ -1,0 +1,113 @@
+import 'package:bones_api/bones_api.dart';
+import 'package:swiss_knife/swiss_knife.dart' show parseBool;
+
+/// Base class for Object DB adapters.
+///
+/// A [DBObjectAdapter] implementation is responsible to connect to the database
+/// and store/fecth/delete the objects.
+///
+/// All [DBObjectAdapter]s comes with a built-in connection pool.
+abstract class DBObjectAdapter<C extends Object> extends DBAdapter<C> {
+  static bool _boot = false;
+
+  static void boot() {
+    if (_boot) return;
+    _boot = true;
+
+    DBObjectMemoryAdapter.boot();
+  }
+
+  static final DBAdapterRegister<Object, DBObjectAdapter<Object>>
+      adapterRegister = DBAdapter.adapterRegister.createRegister();
+
+  static List<String> get registeredAdaptersNames =>
+      adapterRegister.registeredAdaptersNames;
+
+  static List<Type> get registeredAdaptersTypes =>
+      adapterRegister.registeredAdaptersTypes;
+
+  static void registerAdapter<C extends Object, A extends DBObjectAdapter<C>>(
+      List<String> names,
+      Type type,
+      DBAdapterInstantiator<C, A> adapterInstantiator) {
+    boot();
+    adapterRegister.registerAdapter(names, type, adapterInstantiator);
+  }
+
+  static DBAdapterInstantiator<C, A>?
+      getAdapterInstantiator<C extends Object, A extends DBObjectAdapter<C>>(
+              {String? name, Type? type}) =>
+          adapterRegister.getAdapterInstantiator<C, A>(name: name, type: type);
+
+  static List<MapEntry<DBAdapterInstantiator<C, A>, Map<String, dynamic>>>
+      getAdapterInstantiatorsFromConfig<C extends Object,
+              A extends DBObjectAdapter<C>>(Map<String, dynamic> config) =>
+          adapterRegister.getAdapterInstantiatorsFromConfig<C, A>(config);
+
+  static bool? parseConfigLog(Map<String, dynamic>? config) {
+    var log = config?['log'];
+    return parseBool(log);
+  }
+
+  final bool log;
+
+  DBObjectAdapter(String name, int minConnections, int maxConnections,
+      DBAdapterCapability capability,
+      {bool generateTables = false,
+      Object? populateTables,
+      super.populateSource,
+      super.parentRepositoryProvider,
+      super.workingPath,
+      this.log = false})
+      : super(
+          name,
+          minConnections,
+          maxConnections,
+          capability,
+        ) {
+    boot();
+
+    parentRepositoryProvider?.notifyKnownEntityRepositoryProvider(this);
+  }
+
+  static FutureOr<A> fromConfig<C extends Object, A extends DBObjectAdapter<C>>(
+      Map<String, dynamic> config,
+      {int minConnections = 1,
+      int maxConnections = 3,
+      EntityRepositoryProvider? parentRepositoryProvider,
+      String? workingPath}) {
+    boot();
+
+    var instantiators = getAdapterInstantiatorsFromConfig<C, A>(config);
+
+    if (instantiators.isEmpty) {
+      throw StateError(
+          "Can't find `$A` instantiator for `config` keys: ${config.keys.toList()}");
+    }
+
+    return DBAdapter.instantiateAdaptor<C, A>(instantiators, config,
+        minConnections: minConnections,
+        maxConnections: maxConnections,
+        parentRepositoryProvider: parentRepositoryProvider,
+        workingPath: workingPath);
+  }
+
+  @override
+  List<Initializable> initializeDependencies() {
+    var parentRepositoryProvider = this.parentRepositoryProvider;
+    return <Initializable>[
+      if (parentRepositoryProvider != null) parentRepositoryProvider
+    ];
+  }
+}
+
+/// Error thrown by [DBObjectAdapter] operations.
+class DBObjectAdapterException extends DBAdapterException {
+  @override
+  String get runtimeTypeNameSafe => 'DBObjectAdapterException';
+
+  DBObjectAdapterException(String type, String message,
+      {Object? parentError, StackTrace? parentStackTrace})
+      : super(type, message,
+            parentError: parentError, parentStackTrace: parentStackTrace);
+}

--- a/lib/src/bones_api_entity_db_postgres.dart
+++ b/lib/src/bones_api_entity_db_postgres.dart
@@ -76,11 +76,12 @@ class DBPostgreSQLAdapter extends DBSQLAdapter<PostgreSQLExecutionContext>
       int? port = 5432,
       int minConnections = 1,
       int maxConnections = 3,
-      bool generateTables = false,
-      Object? populateTables,
-      Object? populateSource,
-      EntityRepositoryProvider? parentRepositoryProvider,
-      String? workingPath})
+      super.generateTables = false,
+      super.populateTables,
+      super.populateSource,
+      super.parentRepositoryProvider,
+      super.workingPath,
+      super.logSQL})
       : host = host ?? 'localhost',
         port = port ?? 5432,
         _password = (password != null && password is! PasswordProvider
@@ -104,11 +105,6 @@ class DBPostgreSQLAdapter extends DBSQLAdapter<PostgreSQLExecutionContext>
               transactions: true,
               transactionAbort: true,
               tableSQL: true),
-          generateTables: generateTables,
-          populateTables: populateTables,
-          populateSource: populateSource,
-          parentRepositoryProvider: parentRepositoryProvider,
-          workingPath: workingPath,
         ) {
     boot();
 
@@ -159,6 +155,8 @@ class DBPostgreSQLAdapter extends DBSQLAdapter<PostgreSQLExecutionContext>
     if (database == null) throw ArgumentError.notNull('database');
     if (username == null) throw ArgumentError.notNull('username');
 
+    var logSql = DBSQLAdapter.parseConfigLogSQL(config) ?? false;
+
     return DBPostgreSQLAdapter(
       database,
       username,
@@ -172,6 +170,7 @@ class DBPostgreSQLAdapter extends DBSQLAdapter<PostgreSQLExecutionContext>
       populateSource: populateSource,
       parentRepositoryProvider: parentRepositoryProvider,
       workingPath: workingPath,
+      logSQL: logSql,
     );
   }
 

--- a/lib/src/bones_api_entity_db_relational.dart
+++ b/lib/src/bones_api_entity_db_relational.dart
@@ -31,70 +31,37 @@ abstract class DBRelationalAdapter<C extends Object> extends DBAdapter<C> {
     DBSQLAdapter.boot();
   }
 
-  static final Map<String, DBAdapterInstantiator> _registeredAdaptersByName =
-      <String, DBAdapterInstantiator>{};
-  static final Map<Type, DBAdapterInstantiator> _registeredAdaptersByType =
-      <Type, DBAdapterInstantiator>{};
+  static final DBAdapterRegister<Object, DBRelationalAdapter<Object>>
+      adapterRegister = DBAdapter.adapterRegister.createRegister();
 
   static List<String> get registeredAdaptersNames =>
-      _registeredAdaptersByName.keys.toList();
+      adapterRegister.registeredAdaptersNames;
 
   static List<Type> get registeredAdaptersTypes =>
-      _registeredAdaptersByType.keys.toList();
+      adapterRegister.registeredAdaptersTypes;
 
   static void
       registerAdapter<C extends Object, A extends DBRelationalAdapter<C>>(
           List<String> names,
           Type type,
           DBAdapterInstantiator<C, A> adapterInstantiator) {
-    for (var name in names) {
-      _registeredAdaptersByName[name] = adapterInstantiator;
-    }
-
-    _registeredAdaptersByType[type] = adapterInstantiator;
-
-    DBAdapter.registerAdapter(names, type, adapterInstantiator);
+    boot();
+    adapterRegister.registerAdapter(names, type, adapterInstantiator);
   }
 
   static DBAdapterInstantiator<C, A>? getAdapterInstantiator<C extends Object,
-      A extends DBRelationalAdapter<C>>({String? name, Type? type}) {
-    if (name == null && type == null) {
-      throw ArgumentError(
-          'One of the parameters `name` or `type` should NOT be null!');
-    }
-
-    if (name != null) {
-      var adapter = _registeredAdaptersByName[name];
-      if (adapter is DBAdapterInstantiator<C, A>) {
-        return adapter;
-      }
-    }
-
-    if (type != null) {
-      var adapter = _registeredAdaptersByType[type];
-      if (adapter is DBAdapterInstantiator<C, A>) {
-        return adapter;
-      }
-    }
-
-    return null;
-  }
+          A extends DBRelationalAdapter<C>>({String? name, Type? type}) =>
+      adapterRegister.getAdapterInstantiator<C, A>(name: name, type: type);
 
   static List<MapEntry<DBAdapterInstantiator<C, A>, Map<String, dynamic>>>
       getAdapterInstantiatorsFromConfig<C extends Object,
               A extends DBRelationalAdapter<C>>(Map<String, dynamic> config) =>
-          DBAdapter.getAdapterInstantiatorsFromConfigImpl<C, A>(
-              config, registeredAdaptersNames, getAdapterInstantiator);
+          adapterRegister.getAdapterInstantiatorsFromConfig<C, A>(config);
 
   DBRelationalAdapter(String name, int minConnections, int maxConnections,
       DBAdapterCapability capability,
-      {EntityRepositoryProvider? parentRepositoryProvider,
-      Object? populateSource,
-      String? workingPath})
-      : super(name, minConnections, maxConnections, capability,
-            parentRepositoryProvider: parentRepositoryProvider,
-            populateSource: populateSource,
-            workingPath: workingPath) {
+      {super.parentRepositoryProvider, super.populateSource, super.workingPath})
+      : super(name, minConnections, maxConnections, capability) {
     boot();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A Powerful API backend framework for Dart. Comes with a built-in HTTP Server, routes handler, entity handler, SQL translator, and DB adapters.
-version: 1.3.56
+version: 1.3.57
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:


### PR DESCRIPTION
- New `DBObjectAdapter`:
  - Base class for `DBObjectMemoryAdapter` and `DBObjectDirectoryAdapter`.
- New `DBAdapterRegister`:
  - handles `DBAdapter` registration, avoiding repetitive static code in `DBSQLAdapter`, `DBObjectAdapter` and `DBRelationalAdapter`.
- `EntityHandler`
  - Added `equalsValuesEntityMap`.
  - Added `getEntityIDFrom`.
  - `equalsValuesEntity` now also using `equalsValuesEntityMap`.
    - This fixes an issue for `DBSQLMemoryAdapter`.