### PR TITLE
v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 ## 1.4.1
 
 - `APIModuleHttpProxy`:
-  - for `POST` request if any parameter is a `List` or `Map`. 
+  - Force `POST` request if any parameter is a `List` or `Map`. 
+- `APIRouteBuilder.resolveValueByType`:
+  - Renamed: `_resolveValueType` to `resolveValueByType`
+  - Exposed and static.
+  - Fix parsing of typed `List`, `Set` and `Map` parameters.
+  - Improved tests.
+- reflection_factory: ^2.1.2
 
 ## 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.1
+
+- `APIModuleHttpProxy`:
+  - for `POST` request if any parameter is a `List` or `Map`. 
+
 ## 1.4.0
 
 - reflection_factory: ^2.1.0

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -40,7 +40,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.4.0';
+  static const String VERSION = '1.4.1';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_module.dart
+++ b/lib/src/bones_api_module.dart
@@ -890,13 +890,17 @@ class APIModuleHttpProxy implements ClassProxyListener {
 
     parameters = parameters.map((key, value) {
       Object? val = value;
-      if ((!value.isPrimitiveValue &&
-              !value.isPrimitiveList &&
-              !value.isPrimitiveMap) ||
-          (value is Uint8List)) {
+
+      if (value is Uint8List) {
+        val = Json.toJson(value);
+        needsJsonRequest = true;
+      } else if (value.isPrimitiveList || value.isPrimitiveMap) {
+        needsJsonRequest = true;
+      } else if (!value.isPrimitiveValue) {
         val = Json.toJson(value);
         needsJsonRequest = true;
       }
+
       return MapEntry(key, val);
     });
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A Powerful API backend framework for Dart. Comes with a built-in HTTP Server, routes handler, entity handler, SQL translator, and DB adapters.
-version: 1.4.0
+version: 1.4.1
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   async_extension: ^1.1.0
   dart_spawner: ^1.0.6
   args: ^2.4.0
-  reflection_factory: ^2.1.0
+  reflection_factory: ^2.1.2
   meta: ^1.9.1
   statistics: ^1.0.25
   petitparser: ^5.3.0

--- a/test/bones_api_module_test.dart
+++ b/test/bones_api_module_test.dart
@@ -284,6 +284,139 @@ void main() {
       apiRoot.close();
     });
   });
+
+  group('APIRouteBuilder.resolveValueType', () {
+    test('int', () {
+      var t = TypeInfo(int);
+      expect(APIRouteBuilder.resolveValueByType(t, 123), equals(123));
+      expect(APIRouteBuilder.resolveValueByType(t, '456'), equals(456));
+      expect(APIRouteBuilder.resolveValueByType(t, '"567"'), equals(567));
+    });
+
+    test('double', () {
+      var t = TypeInfo(double);
+      expect(APIRouteBuilder.resolveValueByType(t, 123),
+          allOf(equals(123.0), isA<double>()));
+      expect(APIRouteBuilder.resolveValueByType(t, 12.3), equals(12.3));
+      expect(APIRouteBuilder.resolveValueByType(t, '45.6'), equals(45.6));
+      expect(APIRouteBuilder.resolveValueByType(t, '"56.7"'), equals(56.7));
+    });
+
+    test('num', () {
+      var t = TypeInfo(num);
+      expect(APIRouteBuilder.resolveValueByType(t, 123), equals(123));
+      expect(APIRouteBuilder.resolveValueByType(t, 12.3), equals(12.3));
+      expect(APIRouteBuilder.resolveValueByType(t, '45.6'), equals(45.6));
+      expect(APIRouteBuilder.resolveValueByType(t, '"56.7"'), equals(56.7));
+    });
+
+    test('String', () {
+      var t = TypeInfo(String);
+      expect(APIRouteBuilder.resolveValueByType(t, 123), equals('123'));
+      expect(APIRouteBuilder.resolveValueByType(t, 12.3), equals('12.3'));
+      expect(APIRouteBuilder.resolveValueByType(t, '45.6'), equals('45.6'));
+      expect(APIRouteBuilder.resolveValueByType(t, '"56.7"'), equals('"56.7"'));
+    });
+
+    test('List', () {
+      var t = TypeInfo<List>(List);
+      expect(APIRouteBuilder.resolveValueByType(t, 123), equals([123]));
+      expect(APIRouteBuilder.resolveValueByType(t, '123'), equals(['123']));
+      expect(APIRouteBuilder.resolveValueByType(t, [12, 34.5]),
+          equals([12, 34.5]));
+      expect(APIRouteBuilder.resolveValueByType(t, '45.6'), equals(['45.6']));
+      expect(
+          APIRouteBuilder.resolveValueByType(t, '"56.7"'), equals(['"56.7"']));
+      expect(
+          APIRouteBuilder.resolveValueByType(t, '45, 6'), equals(['45', '6']));
+      expect(
+          APIRouteBuilder.resolveValueByType(t, '45;6'), equals(['45', '6']));
+    });
+
+    test('List<int>', () {
+      var t = TypeInfo<List<int>>(List, [int]);
+      expect(APIRouteBuilder.resolveValueByType(t, 123), equals([123]));
+      expect(APIRouteBuilder.resolveValueByType(t, '123'), equals([123]));
+      expect(
+          APIRouteBuilder.resolveValueByType(t, [12, 34.5]), equals([12, 34]));
+      expect(APIRouteBuilder.resolveValueByType(t, '45.6'), equals([45]));
+      expect(APIRouteBuilder.resolveValueByType(t, '"56.7"'), equals([56]));
+      expect(APIRouteBuilder.resolveValueByType(t, '45, 6'), equals([45, 6]));
+      expect(APIRouteBuilder.resolveValueByType(t, '45;6'), equals([45, 6]));
+    });
+
+    test('List<double>', () {
+      var t = TypeInfo<List<double>>(List, [double]);
+      expect(APIRouteBuilder.resolveValueByType(t, 123), equals([123.0]));
+      expect(APIRouteBuilder.resolveValueByType(t, '123'), equals([123.0]));
+      expect(APIRouteBuilder.resolveValueByType(t, [12, 34.5]),
+          equals([12, 34.5]));
+      expect(APIRouteBuilder.resolveValueByType(t, '45.6'), equals([45.6]));
+      expect(APIRouteBuilder.resolveValueByType(t, '"56.7"'), equals([56.7]));
+      expect(
+          APIRouteBuilder.resolveValueByType(t, '45, 6'), equals([45.0, 6.0]));
+      expect(
+          APIRouteBuilder.resolveValueByType(t, '45;6.1'), equals([45.0, 6.1]));
+    });
+
+    test('Set', () {
+      var t = TypeInfo<Set>(Set);
+      expect(APIRouteBuilder.resolveValueByType(t, 123), equals({123}));
+      expect(APIRouteBuilder.resolveValueByType(t, '123'), equals({'123'}));
+      expect(APIRouteBuilder.resolveValueByType(t, [12, 34.5]),
+          equals([12, 34.5]));
+      expect(APIRouteBuilder.resolveValueByType(t, '45.6'), equals({'45.6'}));
+      expect(
+          APIRouteBuilder.resolveValueByType(t, '"56.7"'), equals({'"56.7"'}));
+      expect(
+          APIRouteBuilder.resolveValueByType(t, '45, 6'), equals({'45', '6'}));
+      expect(
+          APIRouteBuilder.resolveValueByType(t, '45;6'), equals({'45', '6'}));
+    });
+
+    test('Set<int>', () {
+      var t = TypeInfo<Set<int>>(Set, [int]);
+      expect(APIRouteBuilder.resolveValueByType(t, 123), equals({123}));
+      expect(APIRouteBuilder.resolveValueByType(t, '123'), equals({123}));
+      expect(
+          APIRouteBuilder.resolveValueByType(t, [12, 34.5]), equals({12, 34}));
+      expect(APIRouteBuilder.resolveValueByType(t, '45.6'), equals({45}));
+      expect(APIRouteBuilder.resolveValueByType(t, '"56.7"'), equals({56}));
+      expect(APIRouteBuilder.resolveValueByType(t, '45, 6'), equals({45, 6}));
+      expect(APIRouteBuilder.resolveValueByType(t, '45;6'), equals({45, 6}));
+    });
+
+    test('Set<double>', () {
+      var t = TypeInfo<Set<double>>(Set, [double]);
+      expect(APIRouteBuilder.resolveValueByType(t, 123), equals({123.0}));
+      expect(APIRouteBuilder.resolveValueByType(t, '123'), equals({123.0}));
+      expect(APIRouteBuilder.resolveValueByType(t, {12, 34.5}),
+          equals([12, 34.5]));
+      expect(APIRouteBuilder.resolveValueByType(t, '45.6'), equals({45.6}));
+      expect(APIRouteBuilder.resolveValueByType(t, '"56.7"'), equals({56.7}));
+      expect(
+          APIRouteBuilder.resolveValueByType(t, '45, 6'), equals({45.0, 6.0}));
+      expect(
+          APIRouteBuilder.resolveValueByType(t, '45;6.1'), equals({45.0, 6.1}));
+    });
+
+    test('Map', () {
+      var t = TypeInfo<Map>(Map);
+      expect(APIRouteBuilder.resolveValueByType(t, 123), equals({123: null}));
+      expect(
+          APIRouteBuilder.resolveValueByType(t, '123'), equals({'123': null}));
+      expect(APIRouteBuilder.resolveValueByType(t, [12, 34]),
+          equals({12: null, 34: null}));
+      expect(APIRouteBuilder.resolveValueByType(t, 'a:123 ; b:456'),
+          equals({'a': '123', 'b': '456'}));
+    });
+
+    test('Map<String,int>', () {
+      var t = TypeInfo<Map<String, int>>(Map, [String, int]);
+      expect(APIRouteBuilder.resolveValueByType(t, 'a:123 ; b:456'),
+          equals({'a': 123, 'b': 456}));
+    });
+  });
 }
 
 User _buildTestUser() {

--- a/test/bones_api_test.reflection.g.dart
+++ b/test/bones_api_test.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.1.1
+// BUILDER: reflection_factory/2.1.2
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.1.1');
+  static final Version _version = Version.parse('2.1.2');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/test/bones_api_test.reflection.g.dart
+++ b/test/bones_api_test.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.1.0
+// BUILDER: reflection_factory/2.1.1
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.1.0');
+  static final Version _version = Version.parse('2.1.1');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/test/bones_api_test_entities.reflection.g.dart
+++ b/test/bones_api_test_entities.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.1.1
+// BUILDER: reflection_factory/2.1.2
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.1.1');
+  static final Version _version = Version.parse('2.1.2');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/test/bones_api_test_entities.reflection.g.dart
+++ b/test/bones_api_test_entities.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.1.0
+// BUILDER: reflection_factory/2.1.1
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.1.0');
+  static final Version _version = Version.parse('2.1.1');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/test/bones_api_test_modules.reflection.g.dart
+++ b/test/bones_api_test_modules.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.1.1
+// BUILDER: reflection_factory/2.1.2
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.1.1');
+  static final Version _version = Version.parse('2.1.2');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/test/bones_api_test_modules.reflection.g.dart
+++ b/test/bones_api_test_modules.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.1.0
+// BUILDER: reflection_factory/2.1.1
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.1.0');
+  static final Version _version = Version.parse('2.1.1');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/test/bones_api_test_utils_test.reflection.g.dart
+++ b/test/bones_api_test_utils_test.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.1.1
+// BUILDER: reflection_factory/2.1.2
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.1.1');
+  static final Version _version = Version.parse('2.1.2');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/test/bones_api_test_utils_test.reflection.g.dart
+++ b/test/bones_api_test_utils_test.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.1.0
+// BUILDER: reflection_factory/2.1.1
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -17,7 +17,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.1.0');
+  static final Version _version = Version.parse('2.1.1');
 
   Version get reflectionFactoryVersion => _version;
 


### PR DESCRIPTION


- `APIModuleHttpProxy`:
  - Force `POST` request if any parameter is a `List` or `Map`. 
- `APIRouteBuilder.resolveValueByType`:
  - Renamed: `_resolveValueType` to `resolveValueByType`
  - Exposed and static.
  - Fix parsing of typed `List`, `Set` and `Map` parameters.
  - Improved tests.
- reflection_factory: ^2.1.2
