### PR TITLE
1.4.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
 - `LogFileRotate`:
   - Fix `needRotation` for a log file not created yet.
 
+- async_events: ^1.0.12
+- stream_channel: ^2.1.2
+- gcloud: ^0.8.10
+- postgres: ^2.6.2
+- petitparser: ^5.4.0
+
 ## 1.4.20
 
 - `ConditionElement`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.4.21
+
+- `ConditionSQLEncoder`:
+  - `resolveValueToCompatibleType`: force `DateTime.toUtc()` to avoid DB adapter issues.
+- `Transaction`
+  - Added `waitOperation`.
+- `EntityRepository`:
+  - `ensureStored` implementations (`DBRelationalEntityRepository`, `DBEntityRepository`, `IterableEntityRepository`):
+    - Avoid multiple `store` of the same entity in the same [Transaction].
+      - Fix issue with unique fields. 
+- `EntityFieldInvalid`:
+  - Added field `operation`. 
+- `APIDBModule`:
+  - select: sort entities by id.
+  - update: fix enum selected option (`HTMLInput`).
+
 ## 1.4.20
 
 - `ConditionElement`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@
 - `EntityRepository`:
   - `ensureStored` implementations (`DBRelationalEntityRepository`, `DBEntityRepository`, `IterableEntityRepository`):
     - Avoid multiple `store` of the same entity in the same [Transaction].
-      - Fix issue with unique fields. 
+      - Fix issue with unique fields.
+    - Throws `RecursiveRelationshipLoopError` if a loop is detected. 
 - `EntityFieldInvalid`:
   - Added field `operation`. 
+- Added missing `APIRequestMethod.HEAD`.
+- `EntityHandler`:
+  - Avoid recursive loop call to `_validateFieldValueImpl`.
 - `APIDBModule`:
   - select: sort entities by id.
   - update: fix enum selected option (`HTMLInput`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - `APIDBModule`:
   - select: sort entities by id.
   - update: fix enum selected option (`HTMLInput`).
+- `LogFileRotate`:
+  - Fix `needRotation` for a log file not created yet.
 
 ## 1.4.20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - `resolveValueToCompatibleType`: force `DateTime.toUtc()` to avoid DB adapter issues.
 - `Transaction`
   - Added `waitOperation`.
+    - Added `timeout` parameter.
 - `EntityRepository`:
   - `ensureStored` implementations (`DBRelationalEntityRepository`, `DBEntityRepository`, `IterableEntityRepository`):
     - Avoid multiple `store` of the same entity in the same [Transaction].

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -41,7 +41,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.4.20';
+  static const String VERSION = '1.4.21';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -509,6 +509,7 @@ abstract class APIRoot with Initializable, Closable {
       }
     }).resolveMapped((response) {
       currentAPIRequest.remove(contextZone: callZone);
+      response._apiRequest = request;
 
       if (response.isError && response.headers[_callZonedErrorHeader] == true) {
         var stackTrace = response.stackTrace;
@@ -518,8 +519,6 @@ abstract class APIRoot with Initializable, Closable {
           throw response.error;
         }
       }
-
-      response._apiRequest = request;
 
       return response;
     });
@@ -1053,6 +1052,8 @@ enum APIRequestMethod {
   PATCH,
   // ignore: constant_identifier_names
   OPTIONS,
+  // ignore: constant_identifier_names
+  HEAD,
 }
 
 /// Extension of enum [APIRequestMethod].
@@ -1071,6 +1072,8 @@ extension APIRequestMethodExtension on APIRequestMethod {
         return 'PATCH';
       case APIRequestMethod.OPTIONS:
         return 'OPTIONS';
+      case APIRequestMethod.HEAD:
+        return 'HEAD';
       default:
         throw ArgumentError('Unknown method: $this');
     }
@@ -1101,6 +1104,9 @@ APIRequestMethod? parseAPIRequestMethod(String? method) {
     case 'optionS':
     case 'OPTIONS':
       return APIRequestMethod.OPTIONS;
+    case 'head':
+    case 'HEAD':
+      return APIRequestMethod.HEAD;
     default:
       return null;
   }
@@ -1482,6 +1488,19 @@ class APIRequest extends APIPayload {
         headers: headers ?? <String, dynamic>{},
         payload: payload,
         payloadMimeType: payloadMimeType,
+        credential: credential);
+  }
+
+  /// Creates a request of `HEAD` method.
+  factory APIRequest.head(String path,
+      {Map<String, dynamic>? parameters,
+      Map<String, dynamic>? headers,
+      dynamic payload,
+      APICredential? credential}) {
+    return APIRequest(APIRequestMethod.HEAD, path,
+        parameters: parameters ?? <String, dynamic>{},
+        headers: headers ?? <String, dynamic>{},
+        payload: payload,
         credential: credential);
   }
 

--- a/lib/src/bones_api_condition_sql.dart
+++ b/lib/src/bones_api_condition_sql.dart
@@ -448,7 +448,9 @@ class ConditionSQLEncoder extends ConditionEncoder {
 
   @override
   FutureOr<Object?> resolveValueToCompatibleType(Object? value) {
-    if (value is Decimal) {
+    if (value is DateTime) {
+      return value.toUtc();
+    } else if (value is Decimal) {
       return value.toDouble();
     } else if (value is DynamicInt) {
       return value.toBigInt();

--- a/lib/src/bones_api_db_module.dart
+++ b/lib/src/bones_api_db_module.dart
@@ -298,6 +298,25 @@ class APIDBModule extends APIModule {
       list = selectByQuery.toList();
     }
 
+    list.sort((a, b) {
+      var id1 = entityRepository.getEntityID(a);
+      var id2 = entityRepository.getEntityID(b);
+
+      if (id1 == null && id2 == null) {
+        return 0;
+      } else if (id1 == null) {
+        return 1;
+      } else if (id2 == null) {
+        return -1;
+      } else if (id1 is num && id2 is num) {
+        return id1.compareTo(id2);
+      } else if (id1 is String && id2 is String) {
+        return id1.compareTo(id2);
+      } else {
+        return 0;
+      }
+    });
+
     if (json) {
       var entitiesJson = _entitiesToJsonMap(list);
       return APIResponse.ok(entitiesJson, mimeType: 'json');

--- a/lib/src/bones_api_entity_annotation.dart
+++ b/lib/src/bones_api_entity_annotation.dart
@@ -319,3 +319,46 @@ class EntityFieldInvalid extends Error {
     return 'Invalid entity$entityStr field$fieldStr> $message$operationStr$parentStr';
   }
 }
+
+/// Error thrown when a store of an entity with a recursive relationship loop
+/// is detected.
+///
+/// Example:
+/// - `A -> B -> C -> A`
+class RecursiveRelationshipLoopError extends Error
+    implements WithRuntimeTypeNameSafe {
+  @override
+  String get runtimeTypeNameSafe => 'RecursiveRelationshipLoopError';
+
+  final String message;
+
+  final Transaction? transaction;
+  final TransactionOperation? storeOp;
+  final TransactionOperation? parentOp;
+  final Object? entity;
+
+  RecursiveRelationshipLoopError(this.message,
+      {this.transaction, this.storeOp, this.parentOp, this.entity});
+
+  factory RecursiveRelationshipLoopError.fromTransaction(
+      Transaction transaction,
+      TransactionOperation storeOp,
+      TransactionOperation? parentOp,
+      Object entity) {
+    return RecursiveRelationshipLoopError(
+        "Can't store `Transaction#${transaction.id}` with recursive relationship loop:\n"
+        "-- Parent operation: $parentOp\n"
+        "-- Store operation: $storeOp\n"
+        "-- Entity: $entity\n"
+        "-- Transaction:\n${transaction.toString()}",
+        transaction: transaction,
+        storeOp: storeOp,
+        parentOp: parentOp,
+        entity: entity);
+  }
+
+  @override
+  String toString() {
+    return 'RecursiveRelationshipLoopError: $message';
+  }
+}

--- a/lib/src/bones_api_entity_db_postgres.dart
+++ b/lib/src/bones_api_entity_db_postgres.dart
@@ -231,11 +231,14 @@ class DBPostgreSQLAdapter extends DBSQLAdapter<PostgreSQLExecutionContext>
           return EntityFieldInvalid("unique", error.detail,
               fieldName: error.columnName,
               tableName: error.tableName,
-              parentError: error);
+              parentError: error,
+              operation: operation);
         } else if (error.code == '23503') {
           return DBPostgreSQLAdapterException("delete.constraint",
               '${error.message} ; Detail: ${error.detail} ; Table: ${error.tableName} ; Constraint: ${error.constraintName}',
-              parentError: error, parentStackTrace: stackTrace);
+              parentError: error,
+              parentStackTrace: stackTrace,
+              operation: operation);
         }
       }
     }

--- a/lib/src/bones_api_extension.dart
+++ b/lib/src/bones_api_extension.dart
@@ -89,7 +89,7 @@ extension ClassReflectionExtension<O> on ClassReflection<O> {
       entityHandler.checkFieldValue(obj ?? object!, key,
           value: value, nullValue: nullValue);
 
-  bool allFieldsValids<V>({O? obj}) =>
+  bool allFieldsValids({O? obj}) =>
       entityHandler.allFieldsValids(obj ?? object!);
 
   Map<String, EntityFieldInvalid>? validateAllFields<V>({O? obj}) =>

--- a/lib/src/bones_api_html_document.dart
+++ b/lib/src/bones_api_html_document.dart
@@ -389,7 +389,9 @@ class HTMLInput {
         var html = StringBuffer();
         html.write('<select id="field_$name" name="$name">\n');
 
-        valStr = value != null ? value.toString().trim() : '';
+        valStr = value != null
+            ? (enumReflection.name(value) ?? value.toString().split('.').last)
+            : '';
 
         for (var e in enumReflection.values) {
           var enumName = enumReflection.name(e) ?? '';

--- a/lib/src/bones_api_logging_io.dart
+++ b/lib/src/bones_api_logging_io.dart
@@ -298,6 +298,9 @@ class LogFileRotate {
   }
 
   Future<bool> needRotation() async {
+    var fileExists = await file.exists();
+    if (!fileExists) return false;
+
     if (await checkMaxLength()) return true;
     if (await checkMaxAge()) return true;
     return false;

--- a/lib/src/bones_api_module.dart
+++ b/lib/src/bones_api_module.dart
@@ -98,6 +98,9 @@ abstract class APIModule with Initializable {
   final Map<String, APIRouteHandler> _routesHandlersPATH =
       <String, APIRouteHandler>{};
 
+  final Map<String, APIRouteHandler> _routesHandlersHEAD =
+      <String, APIRouteHandler>{};
+
   /// Returns all the routes names.
   Set<String> get allRoutesNames => {
         ..._routesHandlers.keys,
@@ -106,6 +109,7 @@ abstract class APIModule with Initializable {
         ..._routesHandlersPUT.keys,
         ..._routesHandlersDELETE.keys,
         ..._routesHandlersPATH.keys,
+        ..._routesHandlersHEAD.keys,
       };
 
   /// Returns the routes names for [method].
@@ -115,6 +119,10 @@ abstract class APIModule with Initializable {
   }
 
   Map<String, APIRouteHandler> _getRoutesHandlers(APIRequestMethod? method) {
+    if (method == null) {
+      return _routesHandlers;
+    }
+
     switch (method) {
       case APIRequestMethod.GET:
         return _routesHandlersGET;
@@ -126,7 +134,9 @@ abstract class APIModule with Initializable {
         return _routesHandlersDELETE;
       case APIRequestMethod.PATCH:
         return _routesHandlersPATH;
-      default:
+      case APIRequestMethod.HEAD:
+        return _routesHandlersHEAD;
+      case APIRequestMethod.OPTIONS:
         return _routesHandlers;
     }
   }
@@ -372,6 +382,12 @@ class APIRouteBuilder<M extends APIModule> {
       add(APIRequestMethod.PATCH, name, function,
           parameters: parameters, rules: rules);
 
+  /// Adds a route of [name] with [handler] for `HEAD` request method.
+  APIModule head(String name, APIRouteFunction function,
+          {Map<String, TypeInfo>? parameters, Iterable<APIRouteRule>? rules}) =>
+      add(APIRequestMethod.HEAD, name, function,
+          parameters: parameters, rules: rules);
+
   /// Adds a route of [name] with [handler] for the request [method].
   APIModule add(
           APIRequestMethod? method, String name, APIRouteFunction function,
@@ -398,6 +414,9 @@ class APIRouteBuilder<M extends APIModule> {
 
   /// Adds routes from [provider] for `PATCH` request method.
   void patchFrom(Object? provider) => from(APIRequestMethod.PATCH, provider);
+
+  /// Adds routes from [provider] for `HEAD` request method.
+  void headFrom(Object? provider) => from(APIRequestMethod.HEAD, provider);
 
   /// Adds routes from [provider] for the request [requestMethod].
   ///

--- a/lib/src/bones_api_server.dart
+++ b/lib/src/bones_api_server.dart
@@ -1157,6 +1157,12 @@ class APIServer {
       });
     }
 
+    var apiRequestMethod = apiResponse.apiRequest?.method;
+
+    if (apiRequestMethod == APIRequestMethod.HEAD) {
+      return null;
+    }
+
     if (payload is String) {
       apiResponse.payloadMimeType ??=
           resolveBestTextMimeType(payload, apiResponse.payloadFileExtension);

--- a/lib/src/bones_api_server.dart
+++ b/lib/src/bones_api_server.dart
@@ -663,7 +663,7 @@ class APIServer {
   FutureOr<APIRequest> toAPIRequest(Request request) {
     var requestTime = DateTime.now();
 
-    var method = parseAPIRequestMethod(request.method)!;
+    var method = parseAPIRequestMethod(request.method) ?? APIRequestMethod.GET;
 
     var headers = Map.fromEntries(request.headersAll.entries.map((e) {
       var values = e.value;

--- a/lib/src/bones_api_utils.dart
+++ b/lib/src/bones_api_utils.dart
@@ -386,3 +386,69 @@ extension ExtensionRuntimeTypeNameUnsafe on Object? {
     }
   }
 }
+
+/// A set that matches elements by [identical] function only.
+class IdenticalSet<O> {
+  final List<List<O>?> _groups;
+
+  IdenticalSet({int groups = 7})
+      : _groups = List.filled(groups.clamp(2, 1000), null);
+
+  List<O> _getGroup(o) {
+    var h = o.hashCode;
+    var gIdx = h % _groups.length;
+    var g = _groups[gIdx] ??= <O>[];
+    return g;
+  }
+
+  int get groupsLength => _groups.length;
+
+  int _size = 0;
+
+  int get length => _size;
+
+  bool get isEmpty => _size == 0;
+
+  bool get isNotEmpty => !isEmpty;
+
+  bool contains(O o) {
+    var g = _getGroup(o);
+    return g.any((e) => identical(e, o));
+  }
+
+  bool add(O o) {
+    var g = _getGroup(o);
+
+    if (g.any((e) => identical(e, o))) {
+      return false;
+    }
+
+    g.add(o);
+    ++_size;
+
+    return true;
+  }
+
+  bool remove(O o) {
+    var g = _getGroup(o);
+
+    var idx = g.indexWhere((e) => identical(e, o));
+
+    if (idx >= 0) {
+      g.removeAt(idx);
+      --_size;
+      return true;
+    }
+
+    return false;
+  }
+
+  Iterable<O> toIterable() => _groups.whereNotNull().expand((l) => l);
+
+  List<O> toList() => toIterable().toList();
+
+  @override
+  String toString() {
+    return 'IdenticalSet{groups: $groupsLength, length: $length}';
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,14 +20,14 @@ dependencies:
   reflection_factory: ^2.1.6
   meta: ^1.9.1
   statistics: ^1.0.25
-  petitparser: ^5.3.0
+  petitparser: ^5.4.0
   hotreloader: ^3.0.6
   logging: ^1.1.0
   collection: ^1.17.2
   mime: ^1.0.4
-  postgres: ^2.6.1
+  postgres: ^2.6.2
   mysql1: ^0.20.0
-  gcloud: ^0.8.8
+  gcloud: ^0.8.10
   yaml: ^3.1.2
   yaml_writer: ^1.0.3
   mercury_client: ^2.1.8
@@ -39,9 +39,9 @@ dependencies:
   map_history: ^1.0.3
   docker_commander: ^2.0.15
   data_serializer: ^1.0.7
-  async_events: ^1.0.11
+  async_events: ^1.0.12
   archive: ^3.3.7
-  stream_channel: ^2.1.1
+  stream_channel: ^2.1.2
   http: ^1.1.0
   googleapis_auth: ^1.4.1
   crclib: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A powerful API backend framework for Dart. It comes with a built-in HTTP Server, route handler, entity handler, SQL translator, and DB adapters.
-version: 1.4.20
+version: 1.4.21
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:

--- a/test/bones_api_entity_db_tests_base.dart
+++ b/test/bones_api_entity_db_tests_base.dart
@@ -1692,16 +1692,20 @@ Future<bool> runAdapterTests(
         expect(sel[1]?.number, equals(202));
       }
 
-      // Test multiple sub-store of the same sub-entity.
+      // Test multiple sub-store of the same sub-entity:
+      //
+      //   User#2 -> Address#2 -> Store#1 -> User#1
+      //                       -> Store#2 -> User#1
+      //
       {
         var address1 = Address('EX', 'Extra', 'Street One', 101);
-
         var user1 = User('user111@mail.com', '111', address1, []);
+
         var store1 = Store('1x', 1, owner: user1);
         var store2 = Store('2x', 2, owner: user1);
-
         var address2 = Address('EX', 'Extra', 'Street Double', 202,
             stores: [store1, store2]);
+
         var role2 = Role(RoleType.admin, enabled: true);
         var user2 = User('user222@mail.com', '222', address2, [role2]);
 
@@ -1720,6 +1724,9 @@ Future<bool> runAdapterTests(
       }
 
       // Recursive Relationship Loop Error:
+      //
+      //   User#3 -> Address#3 -> Store#3 -> User#3
+      //
       {
         var store3 = Store('3x', 3);
         var address3 =

--- a/test/bones_api_entity_db_tests_base.dart
+++ b/test/bones_api_entity_db_tests_base.dart
@@ -1092,17 +1092,6 @@ Future<bool> runAdapterTests(
           expect(user4, isNull);
         }
 
-        /*
-        {
-          var user4 = await userAPIRepository
-              .selectFirstByQuery("roles == ?", parameters: {
-            'roles': [3]
-          });
-
-          expect(user4?.id, equals(user3.id));
-        }
-         */
-
         {
           var user4 = await userAPIRepository
               .selectFirstByQuery("roles == ?", parameters: {
@@ -1701,6 +1690,46 @@ Future<bool> runAdapterTests(
 
         expect(sel[0]?.number, equals(201));
         expect(sel[1]?.number, equals(202));
+      }
+
+      // Test multiple sub-store of the same sub-entity.
+      {
+        var address1 = Address('EX', 'Extra', 'Street One', 101);
+
+        var user1 = User('user111@mail.com', '111', address1, []);
+        var store1 = Store('1x', 1, owner: user1);
+        var store2 = Store('2x', 2, owner: user1);
+
+        var address2 = Address('EX', 'Extra', 'Street Double', 202,
+            stores: [store1, store2]);
+        var role2 = Role(RoleType.admin, enabled: true);
+        var user2 = User('user222@mail.com', '222', address2, [role2]);
+
+        var id = await userAPIRepository.store(user2);
+
+        expect(id, isNotNull);
+        expect(id, equals(user2.id));
+
+        expect(user1.id, isNotNull);
+        expect(store1.id, isNotNull);
+        expect(store2.id, isNotNull);
+
+        expect(user2.id, isNotNull);
+        expect(address2.id, isNotNull);
+        expect(role2.id, isNotNull);
+      }
+
+      // Recursive Relationship Loop Error:
+      {
+        var store3 = Store('3x', 3);
+        var address3 =
+            Address('EX', 'Extra', 'Street Triple', 301, stores: [store3]);
+        var role3 = Role(RoleType.admin, enabled: true);
+        var user3 = User('user3@mail.com', '333', address3, [role3]);
+        store3.owner = user3;
+
+        await expectLater(() async => await userAPIRepository.store(user3),
+            throwsA(isA<RecursiveRelationshipLoopError>()));
       }
     });
 

--- a/test/bones_api_entity_test.dart
+++ b/test/bones_api_entity_test.dart
@@ -72,6 +72,7 @@ class APIEntityRepositoryProvider extends EntityRepositoryProvider {
             'id': int,
             'name': String,
             'number': int,
+            'owner': User,
           },
         ),
         TableScheme(

--- a/test/bones_api_test_entities.dart
+++ b/test/bones_api_test_entities.dart
@@ -652,7 +652,9 @@ class Store extends Entity {
 
   int? number;
 
-  Store(this.name, this.number, {this.id});
+  User? owner;
+
+  Store(this.name, this.number, {this.id, this.owner});
 
   Store.empty() : this('', 0);
 
@@ -672,7 +674,8 @@ class Store extends Entity {
 
   @JsonField.hidden()
   @override
-  List<String> get fieldsNames => const <String>['id', 'name', 'number'];
+  List<String> get fieldsNames =>
+      const <String>['id', 'name', 'number', 'owner'];
 
   @override
   V? getField<V>(String key) {
@@ -683,6 +686,8 @@ class Store extends Entity {
         return name as V?;
       case 'number':
         return number as V?;
+      case 'owner':
+        return owner as V?;
       default:
         return null;
     }
@@ -697,6 +702,8 @@ class Store extends Entity {
         return TypeInfo.tString;
       case 'number':
         return TypeInfo.tInt;
+      case 'owner':
+        return TypeInfo.fromType(User);
       default:
         return null;
     }
@@ -734,6 +741,12 @@ class Store extends Entity {
           break;
         }
 
+      case 'owner':
+        {
+          owner = value as User?;
+          break;
+        }
+
       default:
         return;
     }
@@ -744,6 +757,7 @@ class Store extends Entity {
         if (id != null) 'id': id,
         'name': name,
         'number': number,
+        'owner': owner?.toJson(),
       };
 }
 

--- a/test/bones_api_test_entities.reflection.g.dart
+++ b/test/bones_api_test_entities.reflection.g.dart
@@ -2378,14 +2378,17 @@ class Store$reflection extends ClassReflection<Store> with __ReflectionMixin {
             this,
             Store,
             '',
-            () => (String name, int? number, {int? id}) =>
-                Store(name, number, id: id),
+            () => (String name, int? number, {int? id, User? owner}) =>
+                Store(name, number, id: id, owner: owner),
             const <__PR>[
               __PR(__TR.tString, 'name', false, true),
               __PR(__TR.tInt, 'number', true, true)
             ],
             null,
-            const <String, __PR>{'id': __PR(__TR.tInt, 'id', true, false)},
+            const <String, __PR>{
+              'id': __PR(__TR.tInt, 'id', true, false),
+              'owner': __PR(__TR<User>(User), 'owner', true, false)
+            },
             null);
       case 'empty':
         return ConstructorReflection<Store>(this, Store, 'empty',
@@ -2420,7 +2423,8 @@ class Store$reflection extends ClassReflection<Store> with __ReflectionMixin {
     'id',
     'idFieldName',
     'name',
-    'number'
+    'number',
+    'owner'
   ];
 
   @override
@@ -2511,6 +2515,19 @@ class Store$reflection extends ClassReflection<Store> with __ReflectionMixin {
           true,
           (o) => () => o!.number,
           (o) => (v) => o!.number = v,
+          obj,
+          false,
+          false,
+        );
+      case 'owner':
+        return FieldReflection<Store, User?>(
+          this,
+          Store,
+          __TR<User>(User),
+          'owner',
+          true,
+          (o) => () => o!.owner,
+          (o) => (v) => o!.owner = v,
           obj,
           false,
           false,

--- a/test/bones_api_utils_collection_test.dart
+++ b/test/bones_api_utils_collection_test.dart
@@ -25,4 +25,57 @@ void main() {
       expect(RoleType.values.parse(' X '), isNull);
     });
   });
+
+  group('IdenticalSet', () {
+    test('basic', () {
+      var s1 = IdenticalSet<String>();
+
+      expect(s1.isEmpty, isTrue);
+      expect(s1.length, equals(0));
+      expect(s1.toList(), equals([]));
+
+      expect(s1.contains('a'), isFalse);
+      expect(s1.add('a'), isTrue);
+      expect(s1.contains('a'), isTrue);
+
+      expect(s1.length, equals(1));
+      expect(s1.isEmpty, isFalse);
+      expect(s1.isNotEmpty, isTrue);
+
+      expect(s1.toList(), unorderedEquals(['a']));
+
+      expect(s1.contains('b'), isFalse);
+      expect(s1.add('b'), isTrue);
+      expect(s1.contains('b'), isTrue);
+
+      expect(s1.length, equals(2));
+      expect(s1.isEmpty, isFalse);
+      expect(s1.isNotEmpty, isTrue);
+
+      expect(s1.toList(), unorderedEquals(['a', 'b']));
+
+      expect(s1.contains('x'), isFalse);
+      expect(s1.remove('x'), isFalse);
+
+      expect(s1.contains('b'), isTrue);
+      expect(s1.add('b'), isFalse);
+      expect(s1.contains('b'), isTrue);
+
+      expect(s1.length, equals(2));
+      expect(s1.isEmpty, isFalse);
+      expect(s1.isNotEmpty, isTrue);
+
+      expect(s1.toList(), unorderedEquals(['a', 'b']));
+
+      expect(s1.contains('a'), isTrue);
+      expect(s1.remove('a'), isTrue);
+      expect(s1.contains('a'), isFalse);
+
+      expect(s1.length, equals(1));
+      expect(s1.isEmpty, isFalse);
+      expect(s1.isNotEmpty, isTrue);
+
+      expect(s1.toList(), unorderedEquals(['b']));
+    });
+  });
 }


### PR DESCRIPTION
- `ConditionSQLEncoder`:
  - `resolveValueToCompatibleType`: force `DateTime.toUtc()` to avoid DB adapter issues.
- `Transaction`
  - Added `waitOperation`.
- `EntityRepository`:
  - `ensureStored` implementations (`DBRelationalEntityRepository`, `DBEntityRepository`, `IterableEntityRepository`): - Avoid multiple `store` of the same entity in the same [Transaction]. - Fix issue with unique fields.
- `EntityFieldInvalid`:
  - Added field `operation`.
- `APIDBModule`:
  - select: sort entities by id.
  - update: fix enum selected option (`HTMLInput`).