### PR TITLE
v1.4.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.4.28
+
+- `getTableScheme`, `getTableSchemeImpl` and `getTableSchemeForEntityRepository`:
+  - Added optional `contextID` parameter to allow multiple calls with the
+    same `contextID` to share internal caches.
+- `DBMySQLAdapter` and `DBPostgreSQLAdapter`:
+  - Optimize `getTableScheme` and `getRepositoriesSchemes`
+    with use of `contextID` and internal shared caches.
+
+- async_extension: ^1.2.5
+
 ## 1.4.27
 
 - `DBSQLAdapter`:

--- a/lib/bones_api.dart
+++ b/lib/bones_api.dart
@@ -342,6 +342,7 @@ export 'src/bones_api_sql_builder.dart';
 export 'src/bones_api_types.dart';
 export 'src/bones_api_utils.dart';
 export 'src/bones_api_utils_arguments.dart';
+export 'src/bones_api_utils_call.dart';
 export 'src/bones_api_utils_collections.dart';
 export 'src/bones_api_utils_httpclient.dart';
 export 'src/bones_api_utils_instance_tracker.dart';

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -22,8 +22,8 @@ import 'bones_api_logging.dart';
 import 'bones_api_mixin.dart';
 import 'bones_api_module.dart';
 import 'bones_api_security.dart';
-import 'bones_api_utils.dart';
 import 'bones_api_utils_arguments.dart';
+import 'bones_api_utils_call.dart';
 import 'bones_api_utils_json.dart';
 
 final _log = logging.Logger('APIRoot');
@@ -41,7 +41,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.4.27';
+  static const String VERSION = '1.4.28';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_entity.dart
+++ b/lib/src/bones_api_entity.dart
@@ -28,6 +28,7 @@ import 'bones_api_mixin.dart';
 import 'bones_api_platform.dart';
 import 'bones_api_types.dart';
 import 'bones_api_utils.dart';
+import 'bones_api_utils_call.dart';
 import 'bones_api_utils_collections.dart';
 import 'bones_api_utils_instance_tracker.dart';
 import 'bones_api_utils_json.dart';

--- a/lib/src/bones_api_entity_db_memory.dart
+++ b/lib/src/bones_api_entity_db_memory.dart
@@ -897,7 +897,7 @@ class DBSQLMemoryAdapter extends DBSQLAdapter<DBSQLMemoryAdapterContext>
 
   @override
   TableScheme? getTableScheme(String table,
-      {TableRelationshipReference? relationship}) {
+      {TableRelationshipReference? relationship, Object? contextID}) {
     // ignore: discarded_futures
     var ret = super.getTableScheme(table, relationship: relationship);
 
@@ -910,7 +910,8 @@ class DBSQLMemoryAdapter extends DBSQLAdapter<DBSQLMemoryAdapterContext>
 
   @override
   TableScheme? getTableSchemeImpl(
-      String table, TableRelationshipReference? relationship) {
+      String table, TableRelationshipReference? relationship,
+      {Object? contextID}) {
     _log.info('getTableSchemeImpl> $table ; relationship: $relationship');
 
     var tableScheme = tablesSchemes[table];

--- a/lib/src/bones_api_entity_db_object_directory.dart
+++ b/lib/src/bones_api_entity_db_object_directory.dart
@@ -187,7 +187,8 @@ class DBObjectDirectoryAdapter
 
   @override
   TableScheme? getTableSchemeImpl(
-      String table, TableRelationshipReference? relationship) {
+      String table, TableRelationshipReference? relationship,
+      {Object? contextID}) {
     _log.info('getTableSchemeImpl> $table ; relationship: $relationship');
 
     var tableScheme = tablesSchemes[table];

--- a/lib/src/bones_api_entity_db_object_gcs.dart
+++ b/lib/src/bones_api_entity_db_object_gcs.dart
@@ -274,7 +274,8 @@ class DBObjectGCSAdapter extends DBObjectAdapter<DBObjectGCSAdapterContext> {
 
   @override
   TableScheme? getTableSchemeImpl(
-      String table, TableRelationshipReference? relationship) {
+      String table, TableRelationshipReference? relationship,
+      {Object? contextID}) {
     _log.info('getTableSchemeImpl> $table ; relationship: $relationship');
 
     var tableScheme = tablesSchemes[table];

--- a/lib/src/bones_api_entity_db_object_memory.dart
+++ b/lib/src/bones_api_entity_db_object_memory.dart
@@ -225,7 +225,8 @@ class DBObjectMemoryAdapter
 
   @override
   TableScheme? getTableSchemeImpl(
-      String table, TableRelationshipReference? relationship) {
+      String table, TableRelationshipReference? relationship,
+      {Object? contextID}) {
     _log.info('getTableSchemeImpl> $table ; relationship: $relationship');
 
     var tableScheme = tablesSchemes[table];

--- a/lib/src/bones_api_entity_db_sql.dart
+++ b/lib/src/bones_api_entity_db_sql.dart
@@ -669,9 +669,14 @@ abstract class DBSQLAdapter<C extends Object> extends DBRelationalAdapter<C>
 
     final allSchemes = <EntityRepository<Object>, TableScheme?>{};
 
+    // Call `getTableSchemeForEntityRepository` with a `contextID` to allow
+    // shared internal cache between multiple calls:
+    final contextID = List.unmodifiable([this, "getRepositoriesSchemes"]);
+
     for (var block in reposBlocks) {
       var repositorySchemes = await block
-          .map((r) => MapEntry(r, getTableSchemeForEntityRepository(r)))
+          .map((r) => MapEntry(
+              r, getTableSchemeForEntityRepository(r, contextID: contextID)))
           .toMapFromEntries()
           .resolveAllValues();
 

--- a/lib/src/bones_api_utils.dart
+++ b/lib/src/bones_api_utils.dart
@@ -1,4 +1,3 @@
-import 'package:async_extension/async_extension.dart';
 import 'package:collection/collection.dart';
 import 'package:statistics/statistics.dart';
 
@@ -304,63 +303,6 @@ class FieldNameMapper extends KeyMapper<String> {
     var lcSimple = StringUtils.toLowerCaseSimpleCached(key);
 
     return lc != lcSimple ? <String>[lcSimple, lc] : <String>[lc];
-  }
-}
-
-/// Tries to performa a [call].
-/// - If [onSuccessValue] is defined it overwrites the [call] returned value.
-/// - If [onErrorValue] is defined it will be returned in case of error.
-/// - Returns [defaultValue] if [call] returns `null` and [onSuccessValue] or [onErrorValue] are `null`.
-FutureOr<T?> tryCall<T>(FutureOr<T?> Function() call,
-    {T? defaultValue, T? onSuccessValue, T? onErrorValue}) {
-  try {
-    return call().then((ret) => onSuccessValue ?? ret ?? defaultValue,
-        onError: (e) => onErrorValue ?? defaultValue);
-  } catch (_) {
-    return onErrorValue ?? defaultValue;
-  }
-}
-
-/// Tries to performa a [call] synchronously.
-/// - If [onSuccessValue] is defined it overwrites the [call] returned value.
-/// - If [onErrorValue] is defined it will be returned in case of error.
-/// - Returns [defaultValue] if [call] returns `null` and [onSuccessValue] or [onErrorValue] are `null`.
-T? tryCallSync<T>(T? Function() call,
-    {T? defaultValue, T? onSuccessValue, T? onErrorValue}) {
-  try {
-    var ret = call();
-    return onSuccessValue ?? ret ?? defaultValue;
-  } catch (_) {
-    return onErrorValue ?? defaultValue;
-  }
-}
-
-/// Tries to performa a [call].
-/// See [tryCall].
-FutureOr<R?> tryCallMapped<T, R>(FutureOr<T?> Function() call,
-    {R? defaultValue,
-    R? onSuccessValue,
-    R? Function(T? value)? onSuccess,
-    R? onErrorValue,
-    R? Function(Object error, StackTrace s)? onError}) {
-  try {
-    return call().then((ret) {
-      if (onSuccess != null) {
-        return onSuccess(ret) ?? onSuccessValue ?? defaultValue;
-      }
-      return ret
-          .resolveMapped((r) => onSuccessValue ?? r as R? ?? defaultValue);
-    }, onError: (e, s) {
-      if (onError != null) {
-        return onError(e, s) ?? onErrorValue ?? defaultValue;
-      }
-      return onErrorValue ?? defaultValue;
-    });
-  } catch (e, s) {
-    if (onError != null) {
-      return onError(e, s) ?? onErrorValue ?? defaultValue;
-    }
-    return onErrorValue ?? defaultValue;
   }
 }
 

--- a/lib/src/bones_api_utils_call.dart
+++ b/lib/src/bones_api_utils_call.dart
@@ -1,0 +1,58 @@
+import 'package:async_extension/async_extension.dart';
+
+/// Tries to performa a [call].
+/// - If [onSuccessValue] is defined it overwrites the [call] returned value.
+/// - If [onErrorValue] is defined it will be returned in case of error.
+/// - Returns [defaultValue] if [call] returns `null` and [onSuccessValue] or [onErrorValue] are `null`.
+FutureOr<T?> tryCall<T>(FutureOr<T?> Function() call,
+    {T? defaultValue, T? onSuccessValue, T? onErrorValue}) {
+  try {
+    return call().then((ret) => onSuccessValue ?? ret ?? defaultValue,
+        onError: (e) => onErrorValue ?? defaultValue);
+  } catch (_) {
+    return onErrorValue ?? defaultValue;
+  }
+}
+
+/// Tries to performa a [call] synchronously.
+/// - If [onSuccessValue] is defined it overwrites the [call] returned value.
+/// - If [onErrorValue] is defined it will be returned in case of error.
+/// - Returns [defaultValue] if [call] returns `null` and [onSuccessValue] or [onErrorValue] are `null`.
+T? tryCallSync<T>(T? Function() call,
+    {T? defaultValue, T? onSuccessValue, T? onErrorValue}) {
+  try {
+    var ret = call();
+    return onSuccessValue ?? ret ?? defaultValue;
+  } catch (_) {
+    return onErrorValue ?? defaultValue;
+  }
+}
+
+/// Tries to performa a [call].
+/// See [tryCall].
+FutureOr<R?> tryCallMapped<T, R>(FutureOr<T?> Function() call,
+    {R? defaultValue,
+    R? onSuccessValue,
+    R? Function(T? value)? onSuccess,
+    R? onErrorValue,
+    R? Function(Object error, StackTrace s)? onError}) {
+  try {
+    return call().then((ret) {
+      if (onSuccess != null) {
+        return onSuccess(ret) ?? onSuccessValue ?? defaultValue;
+      }
+      return ret
+          .resolveMapped((r) => onSuccessValue ?? r as R? ?? defaultValue);
+    }, onError: (e, s) {
+      if (onError != null) {
+        return onError(e, s) ?? onErrorValue ?? defaultValue;
+      }
+      return onErrorValue ?? defaultValue;
+    });
+  } catch (e, s) {
+    if (onError != null) {
+      return onError(e, s) ?? onErrorValue ?? defaultValue;
+    }
+    return onErrorValue ?? defaultValue;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A powerful API backend framework for Dart. It comes with a built-in HTTP Server, route handler, entity handler, SQL translator, and DB adapters.
-version: 1.4.27
+version: 1.4.28
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:
@@ -14,7 +14,7 @@ dependencies:
   shelf_gzip: ^4.0.1
   shelf_static: ^1.1.2
   shelf_letsencrypt: ^1.2.2
-  async_extension: ^1.2.4
+  async_extension: ^1.2.5
   dart_spawner: ^1.1.0
   args: ^2.4.2
   reflection_factory: ^2.2.1

--- a/test/bones_api_condition_test.dart
+++ b/test/bones_api_condition_test.dart
@@ -492,7 +492,8 @@ void main() {
 class _TestSchemeProvider extends SchemeProvider {
   @override
   TableScheme? getTableSchemeImpl(
-      String table, TableRelationshipReference? relationship) {
+      String table, TableRelationshipReference? relationship,
+      {Object? contextID}) {
     switch (table) {
       case 'account':
         return TableScheme(


### PR DESCRIPTION
- `getTableScheme`, `getTableSchemeImpl` and `getTableSchemeForEntityRepository`:
  - Added optional `contextID` parameter to allow multiple calls with the same `contextID` to share internal caches.
- `DBMySQLAdapter` and `DBPostgreSQLAdapter`:
  - Optimize `getTableScheme` and `getRepositoriesSchemes` with use of `contextID` and internal shared caches.

- async_extension: ^1.2.5