### PR TITLE
v1.5.1 - APIServer workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,12 @@
 
 - `SQLGenerator.generateCreateTableSQL`: skip annotated hidden fields.
 
+- `APISessionSet`: using `SharedStoreField` and `SharedMapField` to store the the sessions.
+
 - New `APITokenStore`:
   - Shared tokens among `Isolate`s. 
 
-- shared_map: ^1.0.6
+- shared_map: ^1.0.8
 - args_simple: ^1.0.0
 - coverage: ^1.7.1
 - vm_service: ^13.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@
 
 - Created an abstract base class `_APIServerBase` for  `APIServer` and `APIServerWorker`.
   - `start` and `stop` methods, delegating to `startImpl` and `stopImpl`.
+  - Add a new boolean property `isStarting` to determine if the server is in the process of starting.
 
 - `APIServer`
   - Support for spawning auxiliary workers in separate isolates when needed.
   - Starting and stopping of auxiliary `APIServerWorker` instances using isolates. Main worker starts normally.
 
 - New `APIServerWorker` to handle multi-worker `APIServer`.
+  - Add `_processWhileInitializing` to handle API requests while the server is still initializing,
+    including a timeout for initialization.
 
 - `APIRoot:`
   - Added `isIsolateCopy`.
@@ -30,7 +33,7 @@
 - New `APITokenStore`:
   - Shared tokens among `Isolate`s. 
 
-- shared_map: ^1.0.9
+- shared_map: ^1.0.10
 - args_simple: ^1.1.0
 - coverage: ^1.7.1
 - vm_service: ^13.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,10 @@
 
 - `SQLGenerator.generateCreateTableSQL`: skip annotated hidden fields.
 
-- New `APITokenStore`.
+- New `APITokenStore`:
+  - Shared tokens among `Isolate`s. 
 
+- shared_map: ^1.0.6
 - args_simple: ^1.0.0
 - coverage: ^1.7.1
 - vm_service: ^13.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@
   - Add `_processWhileInitializing` to handle API requests while the server is still initializing,
     including a timeout for initialization.
 
+- `APIRequest`:
+  - Can also handle metrics.
+  - Added `transactions` field, automatically populated with all the `Transactions` of the request.
+
+- `APIRequest` and `APIResponse`:
+  - Improved metrics: added `description` parameter.
+  - Added `Transaction`s duration to `Server-Timing`.
+
 - `APIRoot:`
   - Added `isIsolateCopy`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@
 - New `APITokenStore`:
   - Shared tokens among `Isolate`s. 
 
-- shared_map: ^1.0.8
-- args_simple: ^1.0.0
+- shared_map: ^1.0.9
+- args_simple: ^1.1.0
 - coverage: ^1.7.1
 - vm_service: ^13.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 1.5.1
+
+- new `APIServerConfig`:
+  - Holds the configuration need for `APIServer` and `APIServerWorker`.
+  - Can be created from command-line arguments or a JSON object.
+
+- Created an abstract base class `_APIServerBase` for  `APIServer` and `APIServerWorker`.
+  - `start` and `stop` methods, delegating to `startImpl` and `stopImpl`.
+
+- `APIServer`
+  - Support for spawning auxiliary workers in separate isolates when needed.
+  - Starting and stopping of auxiliary `APIServerWorker` instances using isolates. Main worker starts normally.
+
+- New `APIServerWorker` to handle multi-worker `APIServer`.
+
+- `APIRoot:`
+  - Added `isIsolateCopy`.
+
+- `DBAdapterCapability`:
+  - Added `multiIsolateSupport`;
+
+- `DBAdapter`
+  - Added `auxiliaryMode` and `enableAuxiliaryMode`.
+  - `DBSQLMemoryAdapter` and `DBObjectMemoryAdapter` don't support `auxiliaryMode`, since they don't support `multiIsolateSupport`.
+
+- `SQLGenerator.generateCreateTableSQL`: skip annotated hidden fields.
+
+- args_simple: ^1.0.0
+- coverage: ^1.7.1
+- vm_service: ^13.0.0
+
 ## 1.5.0
 
 - sdk: '>=3.2.0 <4.0.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 - `SQLGenerator.generateCreateTableSQL`: skip annotated hidden fields.
 
+- New `APITokenStore`.
+
 - args_simple: ^1.0.0
 - coverage: ^1.7.1
 - vm_service: ^13.0.0

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -41,7 +41,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.5.0';
+  static const String VERSION = '1.5.1';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -96,6 +96,29 @@ abstract class APIRoot with Initializable, Closable {
     }
   }
 
+  /// Returns the [APIRoot] by associated [APIRequest] [zone].
+  static ({APIRoot? apiRoot, APIRequest? apiRequest}) getByAPIRequestZone(
+      Zone zone) {
+    var lng = _instances.length;
+
+    if (lng == 1) {
+      var apiRoot = _instances.values.first;
+      var apiRequest = apiRoot.currentAPIRequest.get(zone);
+      if (apiRequest != null) {
+        return (apiRoot: apiRoot, apiRequest: apiRequest);
+      }
+    } else if (lng > 1) {
+      for (var apiRoot in _instances.values) {
+        var apiRequest = apiRoot.currentAPIRequest.get(zone);
+        if (apiRequest != null) {
+          return (apiRoot: apiRoot, apiRequest: apiRequest);
+        }
+      }
+    }
+
+    return (apiRoot: null, apiRequest: null);
+  }
+
   /// Returns an [APIRoot] instance with [name].
   ///
   /// - If [caseSensitive] is `false` will ignore [name] case.
@@ -1145,7 +1168,7 @@ APIRequestMethod? parseAPIRequestMethod(String? method) {
 }
 
 /// Base class for payload.
-abstract class APIPayload {
+mixin APIPayload {
   static MimeType? resolveMimeType(Object? mimeType) {
     if (mimeType == null) return null;
     if (mimeType is MimeType) return mimeType;
@@ -1208,8 +1231,111 @@ extension APIRequesterSourceExtension on APIRequesterSource {
   }
 }
 
+/// An API metric.
+///
+/// - Used by [APIRequest] nad [APIResponse].
+class APIMetric {
+  final String name;
+
+  final Duration? duration;
+
+  final String? description;
+  final int? n;
+
+  APIMetric(this.name, {this.duration, this.description, this.n});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is APIMetric &&
+          runtimeType == other.runtimeType &&
+          name == other.name;
+
+  @override
+  int get hashCode => name.hashCode;
+
+  @override
+  String toString() => 'APIMetric[$name]{${[
+        if (duration != null) 'duration: $duration',
+        if (n != null) 'n: $n',
+        if (description != null) 'description: "$description"'
+      ].join(', ')}';
+}
+
+/// Base class for an [APIMetric] set.
+///
+/// - Used by [APIRequest] nad [APIResponse].
+abstract class APIMetricSet {
+  Map<String, APIMetric>? _metrics;
+
+  APIMetricSet({Map<String, APIMetric>? metrics}) : _metrics = metrics;
+
+  /// Returns `true` if any metric is set. See [metrics].
+  bool get hasMetrics => _metrics != null && _metrics!.isNotEmpty;
+
+  /// Returns the current metrics.
+  Map<String, APIMetric> get metrics => _metrics ??= <String, APIMetric>{};
+
+  /// Set a metric.
+  ///
+  /// This usually is transformed to a `Server-Timing` header.
+  APIMetric setMetric(String name,
+          {Duration? duration, String? description, int? n}) =>
+      metrics[name] =
+          APIMetric(name, duration: duration, description: description, n: n);
+
+  /// Returns a metric.
+  APIMetric? getMetric(String name) => metrics[name];
+
+  Map<String, ({DateTime start, String? description})>? _startedMetrics;
+
+  void _copyStartedMetrics(APIResponse other) {
+    var otherStartedMetrics = other._startedMetrics;
+
+    if (otherStartedMetrics != null && otherStartedMetrics.isNotEmpty) {
+      var startedMetrics = _startedMetrics ??= {};
+      startedMetrics.addAll(otherStartedMetrics);
+    }
+  }
+
+  /// Starts a metric chronometer.
+  DateTime startMetric(String name, {String? description}) {
+    var startedMetrics = _startedMetrics ??= {};
+
+    var time = startedMetrics.putIfAbsent(
+        name, () => (start: DateTime.now(), description: description));
+    return time.start;
+  }
+
+  /// Stops a metric previously started and adds it to [metrics].
+  /// See [startMetric].
+  Duration? stopMetric(String name, {DateTime? now}) {
+    var metric = _startedMetrics?[name];
+    if (metric == null) return null;
+
+    now ??= DateTime.now();
+
+    var duration = now.difference(metric.start);
+    setMetric(name, duration: duration, description: metric.description);
+
+    return duration;
+  }
+
+  void stopAllMetrics({DateTime? now}) {
+    var startedMetrics = _startedMetrics;
+
+    if (startedMetrics != null) {
+      now ??= DateTime.now();
+
+      for (var k in startedMetrics.keys) {
+        stopMetric(k, now: now);
+      }
+    }
+  }
+}
+
 /// Represents an API request.
-class APIRequest extends APIPayload {
+class APIRequest extends APIMetricSet with APIPayload {
   static final TypeInfo typeInfo = TypeInfo.from(APIRequest);
 
   static int _idCount = 0;
@@ -1335,7 +1461,8 @@ class APIRequest extends APIPayload {
       DateTime? time,
       this.parsingDuration,
       Uri? requestedUri,
-      this.originalRequest})
+      this.originalRequest,
+      Map<String, APIMetric>? metrics})
       : parameters = parameters ?? <String, dynamic>{},
         _payloadMimeType = APIPayload.resolveMimeType(payloadMimeType),
         headers = headers ?? <String, dynamic>{},
@@ -1355,7 +1482,8 @@ class APIRequest extends APIPayload {
                     value is List
                         ? value.map((e) => '$e').toList()
                         : '$value'))),
-        time = time ?? DateTime.now();
+        time = time ?? DateTime.now(),
+        super(metrics: metrics);
 
   static APIRequesterSource _resolveRestSource(String? requestAddress) {
     if (requestAddress == null) return APIRequesterSource.unknown;
@@ -1884,6 +2012,21 @@ class APIRequest extends APIPayload {
     return origin;
   }
 
+  final List<Transaction> _transactions = [];
+
+  /// Returns the transactions associated with this request.
+  List<Transaction> get transactions => UnmodifiableListView(_transactions);
+
+  /// Associate a [Transaction] to this request.
+  void addTransaction(Transaction t) {
+    if (!_transactions.contains(t)) {
+      _transactions.add(t);
+    }
+  }
+
+  /// Disassociate a [Transaction] from this request.
+  bool removeTransaction(Transaction t) => _transactions.remove(t);
+
   @override
   String toString({bool withHeaders = true, bool withPayload = true}) {
     var headersStr = withHeaders ? ', headers: $headers' : '';
@@ -2317,7 +2460,7 @@ extension _IntExtension on int {
 }
 
 /// Represents an API response.
-class APIResponse<T> extends APIPayload {
+class APIResponse<T> extends APIMetricSet with APIPayload {
   static final TypeInfo typeInfo = TypeInfo.from(APIResponse);
 
   /// The response status.
@@ -2407,13 +2550,13 @@ class APIResponse<T> extends APIPayload {
       int? keepAliveMaxRequests,
       this.error,
       this.stackTrace,
-      Map<String, Duration>? metrics})
+      Map<String, APIMetric>? metrics})
       : headers = headers ?? <String, dynamic>{},
         payload = _resolvePayload(payload, payloadDynamic),
         _payloadMimeType = APIPayload.resolveMimeType(payloadMimeType),
         keepAliveTimeout = keepAliveTimeout ?? const Duration(seconds: 10),
         keepAliveMaxRequests = keepAliveMaxRequests ?? 1000,
-        _metrics = metrics;
+        super(metrics: metrics);
 
   static T? _resolvePayload<T>(T? payload, Object? payloadDynamic) {
     if (payload != null) return payload;
@@ -2457,7 +2600,7 @@ class APIResponse<T> extends APIPayload {
       int? keepAliveMaxRequests,
       Object? error,
       StackTrace? stackTrace,
-      Map<String, Duration>? metrics}) {
+      Map<String, APIMetric>? metrics}) {
     return APIResponse(status ?? this.status,
         payload: nullPayload
             ? null
@@ -2486,7 +2629,7 @@ class APIResponse<T> extends APIPayload {
       String? fileExtension,
       Duration? keepAliveTimeout,
       int? keepAliveMaxRequests,
-      Map<String, Duration>? metrics}) {
+      Map<String, APIMetric>? metrics}) {
     return APIResponse(APIResponseStatus.OK,
         headers: headers ?? <String, dynamic>{},
         payload: payload,
@@ -2511,7 +2654,7 @@ class APIResponse<T> extends APIPayload {
       CacheControl? cacheControl,
       Duration? keepAliveTimeout,
       int? keepAliveMaxRequests,
-      Map<String, Duration>? metrics}) {
+      Map<String, APIMetric>? metrics}) {
     return APIResponse.ok(
         payload ?? (payloadDynamic == null ? this.payload : null),
         payloadDynamic: payloadDynamic,
@@ -2534,7 +2677,7 @@ class APIResponse<T> extends APIPayload {
       Object? mimeType,
       Duration? keepAliveTimeout,
       int? keepAliveMaxRequests,
-      Map<String, Duration>? metrics}) {
+      Map<String, APIMetric>? metrics}) {
     return APIResponse(APIResponseStatus.NOT_FOUND,
         headers: headers ?? <String, dynamic>{},
         payload: payload,
@@ -2553,7 +2696,7 @@ class APIResponse<T> extends APIPayload {
       Object? mimeType,
       Duration? keepAliveTimeout,
       int? keepAliveMaxRequests,
-      Map<String, Duration>? metrics}) {
+      Map<String, APIMetric>? metrics}) {
     return APIResponse.notFound(
         payload: payload ?? (payloadDynamic == null ? this.payload : null),
         payloadDynamic: payloadDynamic,
@@ -2575,7 +2718,7 @@ class APIResponse<T> extends APIPayload {
       CacheControl? cacheControl,
       Duration? keepAliveTimeout,
       int? keepAliveMaxRequests,
-      Map<String, Duration>? metrics}) {
+      Map<String, APIMetric>? metrics}) {
     return APIResponse(APIResponseStatus.NOT_MODIFIED,
         headers: headers ?? <String, dynamic>{},
         payload: payload,
@@ -2598,7 +2741,7 @@ class APIResponse<T> extends APIPayload {
       CacheControl? cacheControl,
       Duration? keepAliveTimeout,
       int? keepAliveMaxRequests,
-      Map<String, Duration>? metrics}) {
+      Map<String, APIMetric>? metrics}) {
     return APIResponse.notModified(
         payload: payload ?? (payloadDynamic == null ? this.payload : null),
         payloadDynamic: payloadDynamic,
@@ -2618,7 +2761,7 @@ class APIResponse<T> extends APIPayload {
       T? payload,
       Object? payloadDynamic,
       Object? mimeType,
-      Map<String, Duration>? metrics}) {
+      Map<String, APIMetric>? metrics}) {
     return APIResponse(APIResponseStatus.UNAUTHORIZED,
         headers: headers ?? <String, dynamic>{},
         payload: payload,
@@ -2633,7 +2776,7 @@ class APIResponse<T> extends APIPayload {
       Object? payloadDynamic,
       Map<String, dynamic>? headers,
       Object? mimeType,
-      Map<String, Duration>? metrics}) {
+      Map<String, APIMetric>? metrics}) {
     return APIResponse.unauthorized(
         payload: payload ?? (payloadDynamic == null ? this.payload : null),
         payloadDynamic: payloadDynamic,
@@ -2643,11 +2786,20 @@ class APIResponse<T> extends APIPayload {
       .._copyStartedMetrics(this);
   }
 
-  /// Creates a response of status `REDIRECT`.
+  @Deprecated("Use `redirect`")
   factory APIResponse.redirecy(Uri location,
       {Map<String, dynamic>? headers,
       Object? mimeType,
-      Map<String, Duration>? metrics}) {
+      Map<String, APIMetric>? metrics}) {
+    return APIResponse.redirect(location,
+        headers: headers, mimeType: mimeType, metrics: metrics);
+  }
+
+  /// Creates a response of status `REDIRECT`.
+  factory APIResponse.redirect(Uri location,
+      {Map<String, dynamic>? headers,
+      Object? mimeType,
+      Map<String, APIMetric>? metrics}) {
     return APIResponse(APIResponseStatus.REDIRECT,
         headers: headers ?? <String, dynamic>{},
         payloadDynamic: location,
@@ -2655,13 +2807,26 @@ class APIResponse<T> extends APIPayload {
         metrics: metrics);
   }
 
-  /// Transform this response to an `REDIRECT` response.
+  @Deprecated("Use `asRedirect`")
   APIResponse<T> asRedirecy(
       {Uri? location,
       Map<String, dynamic>? headers,
       Object? mimeType,
-      Map<String, Duration>? metrics}) {
-    return APIResponse.redirecy(location ?? Uri.parse('$payload'.trim()),
+      Map<String, APIMetric>? metrics}) {
+    return asRedirect(
+        location: location,
+        headers: headers,
+        mimeType: mimeType,
+        metrics: metrics);
+  }
+
+  /// Transform this response to an `REDIRECT` response.
+  APIResponse<T> asRedirect(
+      {Uri? location,
+      Map<String, dynamic>? headers,
+      Object? mimeType,
+      Map<String, APIMetric>? metrics}) {
+    return APIResponse.redirect(location ?? Uri.parse('$payload'.trim()),
         headers: headers ?? this.headers,
         mimeType: mimeType ?? payloadMimeType,
         metrics: metrics ?? _metrics)
@@ -2674,7 +2839,7 @@ class APIResponse<T> extends APIPayload {
       T? payload,
       Object? payloadDynamic,
       Object? mimeType,
-      Map<String, Duration>? metrics}) {
+      Map<String, APIMetric>? metrics}) {
     return APIResponse(APIResponseStatus.BAD_REQUEST,
         headers: headers ?? <String, dynamic>{},
         payload: payload,
@@ -2689,7 +2854,7 @@ class APIResponse<T> extends APIPayload {
       Object? payloadDynamic,
       Map<String, dynamic>? headers,
       Object? mimeType,
-      Map<String, Duration>? metrics}) {
+      Map<String, APIMetric>? metrics}) {
     return APIResponse.badRequest(
         payload: payload ?? (payloadDynamic == null ? this.payload : null),
         payloadDynamic: payloadDynamic,
@@ -2704,7 +2869,7 @@ class APIResponse<T> extends APIPayload {
       {Map<String, dynamic>? headers,
       dynamic error,
       StackTrace? stackTrace,
-      Map<String, Duration>? metrics}) {
+      Map<String, APIMetric>? metrics}) {
     return APIResponse(APIResponseStatus.ERROR,
         headers: headers ?? <String, dynamic>{},
         error: error,
@@ -2717,7 +2882,7 @@ class APIResponse<T> extends APIPayload {
       {Map<String, dynamic>? headers,
       dynamic error,
       StackTrace? stackTrace,
-      Map<String, Duration>? metrics}) {
+      Map<String, APIMetric>? metrics}) {
     return APIResponse.error(
         headers: headers ?? this.headers,
         error: error ?? this.error,
@@ -2784,67 +2949,6 @@ class APIResponse<T> extends APIPayload {
 
   /// Returns `true` if [status] is a [APIResponseStatus.BAD_REQUEST].
   bool get isBadRequest => status == APIResponseStatus.BAD_REQUEST;
-
-  Map<String, Duration>? _metrics;
-
-  /// Returns `true` if any metric is set. See [metrics].
-  bool get hasMetrics => _metrics != null && _metrics!.isNotEmpty;
-
-  /// Returns the current metrics.
-  Map<String, Duration> get metrics => _metrics ??= <String, Duration>{};
-
-  /// Set a metric.
-  ///
-  /// This usually is transformed to a `Server-Timing` header.
-  setMetric(String name, Duration duration) => metrics[name] = duration;
-
-  /// Returns a metric.
-  getMetric(String name) => metrics[name];
-
-  Map<String, DateTime>? _startedMetrics;
-
-  void _copyStartedMetrics(APIResponse other) {
-    var otherStartedMetrics = other._startedMetrics;
-
-    if (otherStartedMetrics != null && otherStartedMetrics.isNotEmpty) {
-      var startedMetrics = _startedMetrics ??= <String, DateTime>{};
-      startedMetrics.addAll(otherStartedMetrics);
-    }
-  }
-
-  /// Starts a metric chronometer.
-  DateTime startMetric(String name) {
-    var startedMetrics = _startedMetrics ??= <String, DateTime>{};
-
-    var time = startedMetrics.putIfAbsent(name, () => DateTime.now());
-    return time;
-  }
-
-  /// Stops a metric previously started and adds it to [metrics].
-  /// See [startMetric].
-  Duration? stopMetric(String name, {DateTime? now}) {
-    var start = _startedMetrics?[name];
-    if (start == null) return null;
-
-    now ??= DateTime.now();
-
-    var duration = now.difference(start);
-    setMetric(name, duration);
-
-    return duration;
-  }
-
-  void stopAllMetrics({DateTime? now}) {
-    var startedMetrics = _startedMetrics;
-
-    if (startedMetrics != null) {
-      now ??= DateTime.now();
-
-      for (var k in startedMetrics.keys) {
-        stopMetric(k, now: now);
-      }
-    }
-  }
 
   String? getHeader(String headerKey, {String? def}) {
     var val = headers[headerKey];

--- a/lib/src/bones_api_config.dart
+++ b/lib/src/bones_api_config.dart
@@ -158,35 +158,42 @@ class APIConfig {
 
   /// Returns the final value from a path of keys as [E].
   E? getPath<E>(String k0, [Object? k1, Object? k2, Object? k3, Object? k4]) {
+    Object key = k0;
     Object? val = get(k0);
     if (val == null) return null;
 
     if (k1 != null) {
+      key = k1;
       val = val is Map ? val[k1] : (k1 is int && val is List ? val[k1] : null);
       if (val == null) return null;
     }
 
     if (k2 != null) {
+      key = k2;
       val = val is Map ? val[k2] : (k2 is int && val is List ? val[k2] : null);
       if (val == null) return null;
     }
 
     if (k3 != null) {
+      key = k3;
       val = val is Map ? val[k3] : (k3 is int && val is List ? val[k3] : null);
       if (val == null) return null;
     }
 
     if (k4 != null) {
+      key = k4;
       val = val is Map ? val[k4] : (k4 is int && val is List ? val[k4] : null);
       if (val == null) return null;
     }
+
+    val = _resolveValue(key.toString(), val, null);
 
     if (val is! E) {
       var keyPath = [k0, k1, k2, k3, k4].whereNotNull().join('/');
       throw StateError("Can't return key `$keyPath` as `$E`: $val");
     }
 
-    return val as E;
+    return val;
   }
 
   /// Alias to [get] returning a [Map].

--- a/lib/src/bones_api_entity.dart
+++ b/lib/src/bones_api_entity.dart
@@ -16,6 +16,7 @@ import 'package:statistics/statistics.dart'
         IterableExtension;
 import 'package:swiss_knife/swiss_knife.dart' show EventStream, DataURLBase64;
 
+import 'bones_api_base.dart';
 import 'bones_api_condition.dart';
 import 'bones_api_entity_annotation.dart';
 import 'bones_api_entity_reference.dart';
@@ -4505,6 +4506,8 @@ class Transaction extends JsonEntityCacheSimple implements EntityProvider {
 
     _initTime ??= DateTime.now();
 
+    _addToAPIRequest();
+
     _opening = true;
     _transactionCloser = closer;
 
@@ -4586,6 +4589,10 @@ class Transaction extends JsonEntityCacheSimple implements EntityProvider {
     }
 
     _initTime ??= DateTime.now();
+
+    if (_operations.isEmpty) {
+      _addToAPIRequest();
+    }
 
     _operations.add(op);
     op.id = _operations.length;
@@ -4827,6 +4834,8 @@ class Transaction extends JsonEntityCacheSimple implements EntityProvider {
 
     _endTime ??= DateTime.now();
 
+    _addToAPIRequest();
+
     _committed = true;
 
     _close();
@@ -4849,6 +4858,12 @@ class Transaction extends JsonEntityCacheSimple implements EntityProvider {
     }
 
     return result as R?;
+  }
+
+  void _addToAPIRequest() {
+    var (apiRoot: _, apiRequest: apiRequest) =
+        APIRoot.getByAPIRequestZone(Zone.current);
+    apiRequest?.addTransaction(this);
   }
 
   void _close({Zone? zone}) {
@@ -5149,6 +5164,18 @@ class Transaction extends JsonEntityCacheSimple implements EntityProvider {
     var parentTransaction = this.parentTransaction;
     if (parentTransaction != null) {
       parentTransaction.cacheEntities(entities, idGetter);
+    }
+  }
+
+  String get info {
+    final mainOperation = this.mainOperation;
+
+    if (mainOperation != null) {
+      var typeName = mainOperation.type.name;
+      var repositoryName = mainOperation.repositoryName;
+      return 'T#$id $typeName@$repositoryName';
+    } else {
+      return 'Transaction#$id';
     }
   }
 

--- a/lib/src/bones_api_entity_db.dart
+++ b/lib/src/bones_api_entity_db.dart
@@ -272,7 +272,7 @@ abstract class DBAdapter<C extends Object> extends SchemeProvider
 
       if (auxiliaryMode) {
         _disposePopulateData();
-        return _initializationResultOK();
+        return _initializationResultOK(withEntityRepositories: false);
       }
 
       return populateImpl();
@@ -315,14 +315,15 @@ abstract class DBAdapter<C extends Object> extends SchemeProvider
     _disposePopulateData();
 
     if (populateSource == null) {
-      return _initializationResultOK();
+      return _initializationResultOK(withEntityRepositories: false);
     }
 
     return populateFromSource(populateSource,
             workingPath: _workingPath,
             resolutionRules: EntityResolutionRules(allowReadFile: true),
             variables: populateSourceVariables)
-        .resolveMapped((val) => _initializationResultOK());
+        .resolveMapped(
+            (val) => _initializationResultOK(withEntityRepositories: true));
   }
 
   void _disposePopulateData() {
@@ -330,10 +331,11 @@ abstract class DBAdapter<C extends Object> extends SchemeProvider
     _populateSourceVariables = null;
   }
 
-  InitializationResult _initializationResultOK() =>
+  InitializationResult _initializationResultOK(
+          {required bool withEntityRepositories}) =>
       InitializationResult.ok(this, dependencies: [
         if (parentRepositoryProvider != null) parentRepositoryProvider!,
-        ...entityRepositories,
+        if (withEntityRepositories) ...entityRepositories,
       ]);
 
   @override

--- a/lib/src/bones_api_entity_db.dart
+++ b/lib/src/bones_api_entity_db.dart
@@ -30,7 +30,7 @@ class DBDialect {
 }
 
 /// [DBAdapter] capabilities.
-class DBAdapterCapability {
+class DBAdapterCapability implements WithRuntimeTypeNameSafe {
   /// The dialect of the DB.
   final DBDialect dialect;
 
@@ -43,11 +43,25 @@ class DBAdapterCapability {
   /// `true` if the DB fully supports [transactions] and [transactionAbort].
   bool get fullTransaction => transactions && transactionAbort;
 
+  /// `true` if the [DBAdapter] supports execution in multiple [Isolate]s.
+  /// - If an adapter tries to initialize inside an auxiliary [Isolate] ([DBAdapter.auxiliaryMode]), it will fail.
+  final bool multiIsolateSupport;
+
   const DBAdapterCapability({
     required this.dialect,
     required this.transactions,
     required this.transactionAbort,
+    required this.multiIsolateSupport,
   });
+
+  String get info =>
+      'transactions: $transactions, transactionAbort: $transactionAbort, multiIsolateSupport: $multiIsolateSupport';
+
+  @override
+  String get runtimeTypeNameSafe => 'DBAdapterCapability';
+
+  @override
+  String toString() => 'DBAdapterCapability[${dialect.name}]{$info}@$dialect';
 }
 
 typedef DBAdapterInstantiator<C extends Object, A extends DBAdapter<C>>
@@ -106,6 +120,29 @@ abstract class DBAdapter<C extends Object> extends SchemeProvider
   static final WeakList<DBAdapter> _instances = WeakList<DBAdapter>();
 
   static List<DBAdapter> get instances => _instances.toList();
+
+  static bool _auxiliaryMode = false;
+
+  /// Returns `true` if auxiliary mode is enabled.
+  ///
+  /// This mode is activated when an auxiliary isolate is spawned. In this state,
+  /// the DBAdapters within this `Isolate` exclusively function as auxiliary adapters.
+  /// Operations, such as table creation and "populate" ([populateImpl]),
+  /// are exclusively managed by the adapters in the main isolate.
+  ///
+  /// See `APIServerWorker`.
+  static bool get auxiliaryMode => _auxiliaryMode;
+
+  static bool enableAuxiliaryMode() {
+    if (_auxiliaryMode) {
+      return true;
+    }
+
+    _auxiliaryMode = true;
+    _log.info("Enabled `DBAdapter` auxiliary mode.");
+
+    return true;
+  }
 
   /// The name of the adapter.
   final String name;
@@ -222,9 +259,20 @@ abstract class DBAdapter<C extends Object> extends SchemeProvider
 
   @override
   FutureOr<InitializationResult> initialize() {
+    if (auxiliaryMode && !capability.multiIsolateSupport) {
+      _log.severe(
+          "Can't initialize adapter in `DBAdapter.auxiliaryMode`: $this");
+      return InitializationResult.error(this);
+    }
+
     return checkDB().resolveMapped((dbOK) {
       if (!dbOK) {
         throw StateError("Can't initialize `DBAdapter`: Table check failed!");
+      }
+
+      if (auxiliaryMode) {
+        _disposePopulateData();
+        return _initializationResultOK();
       }
 
       return populateImpl();
@@ -264,28 +312,29 @@ abstract class DBAdapter<C extends Object> extends SchemeProvider
 
   FutureOr<InitializationResult> _populateSourceImpl(
       Object? populateSource, Object? populateSourceVariables) {
-    _populateSource = null;
-    _populateSourceVariables = null;
+    _disposePopulateData();
 
     if (populateSource == null) {
-      return InitializationResult.ok(this, dependencies: [
-        if (parentRepositoryProvider != null) parentRepositoryProvider!
-      ]);
+      return _initializationResultOK();
     }
 
     return populateFromSource(populateSource,
             workingPath: _workingPath,
             resolutionRules: EntityResolutionRules(allowReadFile: true),
             variables: populateSourceVariables)
-        .resolveMapped((val) {
-      var result = InitializationResult.ok(this, dependencies: [
+        .resolveMapped((val) => _initializationResultOK());
+  }
+
+  void _disposePopulateData() {
+    _populateSource = null;
+    _populateSourceVariables = null;
+  }
+
+  InitializationResult _initializationResultOK() =>
+      InitializationResult.ok(this, dependencies: [
         if (parentRepositoryProvider != null) parentRepositoryProvider!,
         ...entityRepositories,
       ]);
-
-      return result;
-    });
-  }
 
   @override
   FutureOr<O?> getEntityByID<O>(dynamic id,

--- a/lib/src/bones_api_entity_db_memory.dart
+++ b/lib/src/bones_api_entity_db_memory.dart
@@ -104,7 +104,8 @@ class DBSQLMemoryAdapter extends DBSQLAdapter<DBSQLMemoryAdapterContext>
               ),
               transactions: true,
               transactionAbort: true,
-              tableSQL: false),
+              tableSQL: false,
+              multiIsolateSupport: false),
         ) {
     boot();
 
@@ -916,7 +917,7 @@ class DBSQLMemoryAdapter extends DBSQLAdapter<DBSQLMemoryAdapterContext>
   TableScheme? getTableSchemeImpl(
       String table, TableRelationshipReference? relationship,
       {Object? contextID}) {
-    _log.info('getTableSchemeImpl> $table ; relationship: $relationship');
+    //_log.info('getTableSchemeImpl> $table ; relationship: $relationship');
 
     var tableScheme = tablesSchemes[table];
     if (tableScheme != null) return tableScheme;

--- a/lib/src/bones_api_entity_db_mysql.dart
+++ b/lib/src/bones_api_entity_db_mysql.dart
@@ -103,7 +103,8 @@ class DBMySQLAdapter extends DBSQLAdapter<DBMySqlConnectionWrapper>
               ),
               transactions: true,
               transactionAbort: true,
-              tableSQL: true),
+              tableSQL: true,
+              multiIsolateSupport: true),
         ) {
     boot();
 
@@ -306,7 +307,7 @@ class DBMySQLAdapter extends DBSQLAdapter<DBMySqlConnectionWrapper>
     var connection = await catchFromPool();
 
     try {
-      _log.info('getTableSchemeImpl> $table ; relationship: $relationship');
+      //_log.info('getTableSchemeImpl> $table ; relationship: $relationship');
 
       var sql = "SHOW COLUMNS FROM `$table`";
       var results = await connection.query(sql);

--- a/lib/src/bones_api_entity_db_object_directory.dart
+++ b/lib/src/bones_api_entity_db_object_directory.dart
@@ -90,7 +90,8 @@ class DBObjectDirectoryAdapter
           const DBAdapterCapability(
               dialect: DBDialect('object'),
               transactions: true,
-              transactionAbort: true),
+              transactionAbort: true,
+              multiIsolateSupport: true),
         ) {
     boot();
 
@@ -193,7 +194,7 @@ class DBObjectDirectoryAdapter
   TableScheme? getTableSchemeImpl(
       String table, TableRelationshipReference? relationship,
       {Object? contextID}) {
-    _log.info('getTableSchemeImpl> $table ; relationship: $relationship');
+    //_log.info('getTableSchemeImpl> $table ; relationship: $relationship');
 
     var tableScheme = tablesSchemes[table];
     if (tableScheme != null) return tableScheme;

--- a/lib/src/bones_api_entity_db_object_gcs.dart
+++ b/lib/src/bones_api_entity_db_object_gcs.dart
@@ -104,7 +104,8 @@ class DBObjectGCSAdapter extends DBObjectAdapter<DBObjectGCSAdapterContext> {
           const DBAdapterCapability(
               dialect: DBDialect('object'),
               transactions: true,
-              transactionAbort: true),
+              transactionAbort: true,
+              multiIsolateSupport: true),
         ) {
     boot();
 
@@ -280,7 +281,7 @@ class DBObjectGCSAdapter extends DBObjectAdapter<DBObjectGCSAdapterContext> {
   TableScheme? getTableSchemeImpl(
       String table, TableRelationshipReference? relationship,
       {Object? contextID}) {
-    _log.info('getTableSchemeImpl> $table ; relationship: $relationship');
+    //_log.info('getTableSchemeImpl> $table ; relationship: $relationship');
 
     var tableScheme = tablesSchemes[table];
     if (tableScheme != null) return tableScheme;

--- a/lib/src/bones_api_entity_db_object_memory.dart
+++ b/lib/src/bones_api_entity_db_object_memory.dart
@@ -89,7 +89,8 @@ class DBObjectMemoryAdapter
           const DBAdapterCapability(
               dialect: DBDialect('object'),
               transactions: true,
-              transactionAbort: true),
+              transactionAbort: true,
+              multiIsolateSupport: false),
         ) {
     boot();
 
@@ -231,7 +232,7 @@ class DBObjectMemoryAdapter
   TableScheme? getTableSchemeImpl(
       String table, TableRelationshipReference? relationship,
       {Object? contextID}) {
-    _log.info('getTableSchemeImpl> $table ; relationship: $relationship');
+    //_log.info('getTableSchemeImpl> $table ; relationship: $relationship');
 
     var tableScheme = tablesSchemes[table];
     if (tableScheme != null) return tableScheme;
@@ -390,9 +391,9 @@ class DBObjectMemoryAdapter
   @override
   String toString() {
     var tablesSizes = _tables.map((key, value) => MapEntry(key, value.length));
-    var tablesStr = tablesSizes.isNotEmpty ? ', tables: $tablesSizes' : '';
+    var tablesStr = tablesSizes.isNotEmpty ? 'tables: $tablesSizes' : '';
     var closedStr = isClosed ? ', closed' : '';
-    return 'DBObjectMemoryAdapter#$instanceID{$tablesStr$closedStr}';
+    return 'DBObjectMemoryAdapter#$instanceID{$tablesStr$closedStr}+$capability';
   }
 
   @override

--- a/lib/src/bones_api_entity_db_postgres.dart
+++ b/lib/src/bones_api_entity_db_postgres.dart
@@ -110,7 +110,8 @@ class DBPostgreSQLAdapter extends DBSQLAdapter<PostgreSQLConnectionWrapper>
               ),
               transactions: true,
               transactionAbort: true,
-              tableSQL: true),
+              tableSQL: true,
+              multiIsolateSupport: true),
         ) {
     boot();
 
@@ -399,7 +400,7 @@ class DBPostgreSQLAdapter extends DBSQLAdapter<PostgreSQLConnectionWrapper>
     var connection = await catchFromPool();
 
     try {
-      _log.info('getTableSchemeImpl> $table ; relationship: $relationship');
+      //_log.info('getTableSchemeImpl> $table ; relationship: $relationship');
 
       var sql =
           "SELECT column_name, data_type, column_default, is_updatable FROM information_schema.columns WHERE table_name = '$table'";

--- a/lib/src/bones_api_entity_db_sql.dart
+++ b/lib/src/bones_api_entity_db_sql.dart
@@ -235,14 +235,17 @@ class DBSQLAdapterCapability extends DBAdapterCapability {
   final bool tableSQL;
 
   const DBSQLAdapterCapability(
-      {required SQLDialect dialect,
-      required bool transactions,
-      required bool transactionAbort,
-      required this.tableSQL})
-      : super(
-            dialect: dialect,
-            transactions: transactions,
-            transactionAbort: transactionAbort);
+      {required super.dialect,
+      required super.transactions,
+      required super.transactionAbort,
+      required this.tableSQL,
+      required super.multiIsolateSupport});
+
+  @override
+  String get info => '${super.info}, tableSQL: $tableSQL';
+
+  @override
+  String get runtimeTypeNameSafe => 'DBSQLAdapterCapability';
 }
 
 typedef DBSQLAdapterInstantiator<C extends Object, A extends DBSQLAdapter<C>>
@@ -415,7 +418,7 @@ abstract class DBSQLAdapter<C extends Object> extends DBRelationalAdapter<C>
 
   @override
   FutureOr<bool> checkDB() {
-    if (_generateTables) {
+    if (_generateTables && !DBAdapter.auxiliaryMode) {
       _generateTables = false;
 
       return generateTables().resolveMapped((tables) {
@@ -425,6 +428,7 @@ abstract class DBSQLAdapter<C extends Object> extends DBRelationalAdapter<C>
       });
     }
 
+    _generateTables = false;
     return checkDBTables();
   }
 
@@ -853,7 +857,8 @@ abstract class DBSQLAdapter<C extends Object> extends DBRelationalAdapter<C>
 
     _entityRepositoriesBuildOrderIn = repositories.toList();
 
-    var sqls = generateEntityRepositoresCreateTableSQLs(verbose: true);
+    var sqls = generateEntityRepositoresCreateTableSQLs(
+        verbose: !DBAdapter.auxiliaryMode);
 
     var ordered = sqls.entries.toHierarchicalOrder().map((e) => e.key).toList();
 

--- a/lib/src/bones_api_security.dart
+++ b/lib/src/bones_api_security.dart
@@ -702,12 +702,8 @@ class APITokenStore {
 
   String get sharedTokensID => 'APITokenStore';
 
-  SharedMapField<String, APITokenInfo>? _sharedTokensField;
-
-  FutureOr<SharedMapField<String, APITokenInfo>> _resolveSharedTokensField() {
-    return _sharedTokensField ??=
-        SharedMapField(sharedTokensID, sharedStore: sharedStore);
-  }
+  late final SharedMapField<String, APITokenInfo> _sharedTokensField =
+      SharedMapField(sharedTokensID, sharedStore: sharedStore);
 
   static const Duration _cacheTimeout = Duration(seconds: 5);
 
@@ -718,19 +714,9 @@ class APITokenStore {
     var sharedTokens = _sharedTokens[this];
     if (sharedTokens != null) return sharedTokens;
 
-    var sharedTokensField = _resolveSharedTokensField();
-
-    FutureOr<SharedMap<String, APITokenInfo>> sharedTokensAsync;
-
-    if (sharedTokensField is Future<SharedMapField<String, APITokenInfo>>) {
-      sharedTokensAsync = sharedTokensField.then((sharedTokensField) =>
-          sharedTokensField.sharedMapCached(timeout: _cacheTimeout));
-    } else {
-      sharedTokensAsync =
-          sharedTokensField.sharedMapCached(timeout: _cacheTimeout);
-    }
-
-    return sharedTokensAsync.resolveMapped((sharedTokens) {
+    return _sharedTokensField
+        .sharedMapCached(timeout: _cacheTimeout)
+        .resolveMapped((sharedTokens) {
       _sharedTokens[this] = sharedTokens;
       return sharedTokens;
     });

--- a/lib/src/bones_api_server.dart
+++ b/lib/src/bones_api_server.dart
@@ -1,7 +1,10 @@
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:typed_data';
 
+import 'package:args_simple/args_simple_io.dart';
 import 'package:async_extension/async_extension.dart';
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart' as logging;
@@ -19,6 +22,7 @@ import 'package:swiss_knife/swiss_knife.dart';
 import 'bones_api_authentication.dart';
 import 'bones_api_base.dart';
 import 'bones_api_config.dart';
+import 'bones_api_entity_db.dart';
 import 'bones_api_entity_reference.dart';
 import 'bones_api_entity_rules.dart';
 import 'bones_api_extension.dart';
@@ -34,11 +38,8 @@ final _log = logging.Logger('APIServer');
 
 final _logLetsEncrypt = logging.Logger('LetsEncrypt');
 
-/// An API HTTP Server
-class APIServer {
-  /// The API root of this server.
-  final APIRoot apiRoot;
-
+/// API Server Config.
+class APIServerConfig {
   /// The bind address of this server.
   final String address;
 
@@ -88,6 +89,12 @@ class APIServer {
   /// - If [cookieless] is `true` `SESSIONID` is disabled.
   final bool useSessionID;
 
+  /// The number of [APIServerWorker] instances to spawn.
+  /// - If [totalWorkers] is equal to 1, it will execute 1 [APIServerWorker] in the current [Isolate].
+  /// - If [totalWorkers] is greater than 1, it will execute multiple [APIServerWorker] instances in new [Isolate]s.
+  /// - The [totalWorkers] will be set in the range of 1 to 100.
+  final int totalWorkers;
+
   /// If `true` will remove any `Set-Cookie` or `Cookie` header.
   ///
   /// See [useSessionID].
@@ -96,12 +103,12 @@ class APIServer {
   /// The `cache-control` header for API responses.
   final String apiCacheControl;
 
+  /// The `cache-control` header for static files.
+  final String staticFilesCacheControl;
+
   /// The default value for [apiCacheControl].
   static const String defaultApiCacheControl =
       'private, no-transform, must-revalidate, max-age=0, no-store, no-cache';
-
-  /// The `cache-control` header for static files.
-  final String staticFilesCacheControl;
 
   /// The default value for [staticFilesCacheControl].
   static const String defaultStaticFilesCacheControl =
@@ -110,52 +117,227 @@ class APIServer {
   /// If `true` log messages to [stdout] (console).
   late final bool logToConsole;
 
-  APIServer(
-    this.apiRoot,
-    String address,
-    this.port, {
+  /// The [APIConfig] of the [APIRoot].
+  final APIConfig? apiConfig;
+
+  /// All the parsed arguments, using [ArgsSimple].
+  final ArgsSimple args;
+
+  APIServerConfig({
+    required this.name,
+    required this.version,
+    String? address,
+    int? port,
     int? securePort,
-    this.letsEncrypt = false,
-    this.letsEncryptProduction = false,
-    this.allowRequestLetsEncryptCertificate = true,
-    Object? letsEncryptDirectory,
-    this.name = 'Bones_API',
-    this.version = BonesAPI.VERSION,
-    this.hotReload = false,
+    Object? documentRoot,
     Object? domains,
-    bool useSessionID = true,
+    Object? letsEncryptDirectory,
+    this.letsEncrypt = false,
+    bool? letsEncryptProduction,
+    bool? allowRequestLetsEncryptCertificate,
+    this.hotReload = false,
+    int? totalWorkers = 1,
     this.cookieless = false,
+    bool? useSessionID,
     String? apiCacheControl,
     String? staticFilesCacheControl,
+    this.apiConfig,
     bool? logToConsole,
-  })  : useSessionID = useSessionID && !cookieless,
+    Object? args,
+  })  : address = normalizeAddress(address, apiConfig: apiConfig),
+        port = resolvePort(port, apiConfig: apiConfig),
+        securePort = resolveSecurePort(securePort,
+            apiConfig: apiConfig, letsEncrypt: letsEncrypt),
+        domainsRoots = parseDomains(domains,
+            apiConfig: apiConfig, documentRoot: documentRoot),
+        letsEncryptProduction = resolveLetsEncryptProduction(
+            letsEncryptProduction,
+            apiConfig: apiConfig),
+        allowRequestLetsEncryptCertificate =
+            resolveAllowRequestLetsEncryptCertificate(
+                allowRequestLetsEncryptCertificate,
+                apiConfig: apiConfig),
+        letsEncryptDirectory = resolveLetsEncryptDirectory(letsEncryptDirectory,
+            apiConfig: apiConfig, letsEncrypt: letsEncrypt),
         apiCacheControl =
-            _normalizeHeaderValue(apiCacheControl, defaultApiCacheControl),
-        staticFilesCacheControl = _normalizeHeaderValue(
+            normalizeHeaderValue(apiCacheControl, defaultApiCacheControl),
+        staticFilesCacheControl = normalizeHeaderValue(
             staticFilesCacheControl, defaultStaticFilesCacheControl),
-        securePort = letsEncrypt
-            ? (securePort != null && securePort > 10 ? securePort : 443)
-            : (securePort ?? -1),
-        letsEncryptDirectory = resolveLetsEncryptDirectory(
-            directory: letsEncryptDirectory, letsEncrypt: letsEncrypt),
-        address = _normalizeAddress(address),
-        domainsRoots = parseDomains(domains) ?? <Pattern, Directory>{} {
-    var isLoggingAll = LoggerHandler.getLogAllTo() != null;
+        useSessionID = resolveUseSessionID(cookieless, useSessionID),
+        totalWorkers = resolveTotalWorkers(totalWorkers, apiConfig: apiConfig),
+        logToConsole = resolveLogToConsole(logToConsole, apiConfig: apiConfig),
+        args = resolveArgs(args);
 
-    // If `logToConsole` not defined and NOT logging all set `logToConsole = true`:
-    this.logToConsole = logToConsole ?? !isLoggingAll;
+  static ArgsSimple resolveArgs(Object? args) {
+    if (args == null) return ArgsSimple();
+    if (args is ArgsSimple) return args;
 
-    _configureAPIRoot(apiRoot);
+    if (args is List) {
+      return ArgsSimple.parse(args.map((e) => e.toString()).toList());
+    } else if (args is String) {
+      return ArgsSimple.fromEncodedJson(args);
+    }
+
+    return ArgsSimple();
   }
 
-  static String _normalizeHeaderValue(String? header, String def) {
+  factory APIServerConfig.fromArgs(List<String> args) {
+    var a = ArgsSimple.parse(args);
+
+    var name = a.optionAsString('name', 'Bones_API')!;
+    var version = a.optionAsString('version', '0.0.0')!;
+
+    var port = a.optionAsInt('port');
+    var securePort = a.optionAsInt('secure-port');
+    var address = a.optionAsString('address');
+
+    var letsEncrypt = a.flag('letsencrypt');
+    var letsEncryptProduction = letsEncrypt && a.flag('letsencrypt-production');
+    var allowRequestLetsEncryptCertificate =
+        letsEncrypt && a.flag('allow-request-letsencrypt-certificate');
+    var letsEncryptDirectory =
+        letsEncrypt ? a.optionAsDirectory('letsencrypt-directory') : null;
+
+    var hotReload = a.flag('hot-reload');
+    var totalWorkers = a.optionAsInt('total-workers');
+
+    var cookieless = a.flag('cookieless');
+    var useSessionID = a.flagOr('use-session-id', !cookieless)!;
+
+    var apiCacheControl = a.optionAsString('api-cache-control');
+    var staticFilesCacheControl =
+        a.optionAsString('static-files-cache-control');
+
+    var logToConsole = a.flagOr('log-toConsole', null);
+
+    var documentRoot = a.optionAsDirectory('document-root');
+
+    var domains = a.optionAsList('domains');
+
+    var apiConfigUri = a.optionAsString("api-config");
+    if (apiConfigUri == null) {
+      var arg0 = a.argumentAsString(0);
+      if (arg0 != null &&
+          (arg0.endsWith('.yml') ||
+              arg0.endsWith('.yaml') ||
+              arg0.endsWith('.json'))) {
+        apiConfigUri = arg0;
+      }
+    }
+
+    var apiConfig = apiConfigUri != null ? APIConfig.from(apiConfigUri) : null;
+
+    return APIServerConfig(
+      name: name,
+      version: version,
+      address: address,
+      port: port,
+      securePort: securePort,
+      documentRoot: documentRoot,
+      domains: domains,
+      letsEncryptDirectory: letsEncryptDirectory,
+      letsEncrypt: letsEncrypt,
+      letsEncryptProduction: letsEncryptProduction,
+      allowRequestLetsEncryptCertificate: allowRequestLetsEncryptCertificate,
+      hotReload: hotReload,
+      totalWorkers: totalWorkers,
+      cookieless: cookieless,
+      useSessionID: useSessionID,
+      apiCacheControl: apiCacheControl,
+      staticFilesCacheControl: staticFilesCacheControl,
+      apiConfig: apiConfig,
+      logToConsole: logToConsole,
+      args: a,
+    );
+  }
+
+  static String normalizeAddress(String? address, {APIConfig? apiConfig}) {
+    address ??= apiConfig?.getPath('server', 'address');
+
+    address = address?.trim() ?? '';
+
+    if (address == '*' ||
+        address == '0' ||
+        address == '::' ||
+        address == '0:0:0:0:0:0:0:0') {
+      return '0.0.0.0';
+    }
+
+    if (address.isEmpty ||
+        address == 'local' ||
+        address == '1' ||
+        address == '127' ||
+        address == '::1' ||
+        address == '0:0:0:0:0:0:0:1') {
+      return 'localhost';
+    }
+
+    return address;
+  }
+
+  static int resolvePort(int? port, {APIConfig? apiConfig}) {
+    port ??= apiConfig?.getPath('server', 'port');
+
+    return port != null && port > 10 ? port : 80;
+  }
+
+  static int resolveSecurePort(int? securePort,
+      {APIConfig? apiConfig, bool? letsEncrypt}) {
+    securePort ??= apiConfig?.getPath('server', 'securePort');
+
+    return (letsEncrypt ?? false)
+        ? (securePort != null && securePort > 10 ? securePort : 443)
+        : (securePort ?? -1);
+  }
+
+  static String normalizeHeaderValue(String? header, String def) {
     if (header == null) return def;
     header = header.trim();
     return header.isNotEmpty ? header : def;
   }
 
-  static Directory? resolveLetsEncryptDirectory(
-      {Object? directory, bool letsEncrypt = false}) {
+  static Map<String, Directory> resolveDomainsRoots(List domains,
+      [Directory? rootDir]) {
+    var domainsRoots = domains
+        .map((e) {
+          var s = e.toString();
+          var parts = s.split('=');
+
+          var domain = parts[0];
+
+          if (parts.length == 1) {
+            return rootDir != null ? MapEntry(domain, rootDir) : null;
+          } else {
+            var path = parts[1].trim();
+            var dir = path.isNotEmpty ? Directory(path) : rootDir;
+            return dir != null ? MapEntry(domain, dir) : null;
+          }
+        })
+        .whereNotNull()
+        .toMapFromEntries();
+    return domainsRoots;
+  }
+
+  static bool resolveLetsEncryptProduction(bool? letsEncryptProduction,
+      {APIConfig? apiConfig}) {
+    letsEncryptProduction ??= apiConfig?.getPath('letsencrypt', 'production');
+    letsEncryptProduction ??= false;
+    return letsEncryptProduction;
+  }
+
+  static bool resolveAllowRequestLetsEncryptCertificate(
+      bool? allowRequestLetsEncryptCertificate,
+      {APIConfig? apiConfig}) {
+    allowRequestLetsEncryptCertificate ??=
+        apiConfig?.getPath('letsencrypt', 'allow-request-certificate');
+    allowRequestLetsEncryptCertificate ??= false;
+    return allowRequestLetsEncryptCertificate;
+  }
+
+  static Directory? resolveLetsEncryptDirectory(Object? directory,
+      {APIConfig? apiConfig, bool letsEncrypt = false}) {
+    directory ??= apiConfig?.getPath('letsencrypt', 'directory');
+
     if (directory != null) {
       Directory? dir;
       if (directory is Directory) {
@@ -228,17 +410,49 @@ class APIServer {
     return null;
   }
 
+  static int resolveTotalWorkers(int? totalWorkers, {APIConfig? apiConfig}) {
+    totalWorkers ??= apiConfig?.getPath('server', 'totalWorkers');
+
+    return (totalWorkers ?? 1).clamp(1, 100);
+  }
+
+  static bool resolveUseSessionID(bool cookieless, bool? useSessionID) {
+    return cookieless ? false : (useSessionID ?? true);
+  }
+
+  // If `logToConsole` not defined and NOT logging all, set `logToConsole = true`:
+  static bool resolveLogToConsole(bool? logToConsole, {APIConfig? apiConfig}) {
+    logToConsole ??= apiConfig?.getPath('log', 'console');
+
+    return logToConsole ?? LoggerHandler.getLogAllTo() == null;
+  }
+
   /// Parses a set of domains to serve static files.
   ///
   /// - See: [APIServer.domainsRoots], [parseDomainPattern], [parseDomainDirectory].
-  static Map<Pattern, Directory>? parseDomains(Object? o) {
-    if (o == null) return null;
+  static Map<Pattern, Directory> parseDomains(Object? o,
+      {APIConfig? apiConfig, Object? documentRoot}) {
+    o ??= apiConfig?.get('domains');
+
+    var documentRootDir = parseDomainDirectory(documentRoot);
+
+    var domains = _parseDomains(o);
+
+    var domains2 = {
+      ...domains,
+      if (documentRootDir != null) RegExp(r'.*'): documentRootDir,
+    };
+
+    return domains2;
+  }
+
+  static Map<Pattern, Directory> _parseDomains(Object? o) {
+    if (o == null) return {};
 
     if (o is Map) {
       var map = o.map((key, value) =>
           MapEntry(parseDomainPattern(key), parseDomainDirectory(value)));
-      _removeInvalidDomains(map);
-      return map.isNotEmpty ? map : null;
+      return _removeInvalidDomains(map);
     }
 
     List values;
@@ -252,22 +466,33 @@ class APIServer {
     }
 
     var entries = values.map(parseDomainEntry).whereNotNull().toList();
-    if (entries.isEmpty) return null;
+    if (entries.isEmpty) return {};
 
-    var map = Map<Pattern, Directory>.fromEntries(entries);
-    _removeInvalidDomains(map);
+    var map =
+        _removeInvalidDomains(Map<Pattern, Directory?>.fromEntries(entries));
 
-    return map.isNotEmpty ? map : null;
+    return map.isNotEmpty ? map : {};
   }
 
-  static void _removeInvalidDomains(Map<Pattern, Directory> domains) {
-    domains.removeWhere((key, value) => (key is String && key.isEmpty));
+  static Map<Pattern, Directory> _removeInvalidDomains(
+      Map<Pattern, Directory?> domains) {
+    return domains.entries
+        .map((e) {
+          var domain = e.key;
+          var dir = e.value;
+          if (dir == null || (domain is String && domain.isEmpty)) {
+            return null;
+          }
+          return MapEntry(e.key, dir);
+        })
+        .whereNotNull()
+        .toMapFromEntries();
   }
 
   /// Parses a domain entry as [MapEntry].
   ///
   /// - See [APIServer.domainsRoots].
-  static MapEntry<Pattern, Directory>? parseDomainEntry(Object? o) {
+  static MapEntry<Pattern, Directory?>? parseDomainEntry(Object? o) {
     if (o == null) return null;
     if (o is MapEntry) {
       return MapEntry(parseDomainPattern(o.key), parseDomainDirectory(o.value));
@@ -306,101 +531,126 @@ class APIServer {
   /// Parses a domain [Directory].
   ///
   /// - See [APIServer.domainsRoots].
-  static Directory parseDomainDirectory(Object dir) {
-    if (dir is Directory) return dir;
-    var p = dir.toString();
-    return Directory(p);
+  static Directory? parseDomainDirectory(Object? dirPath) {
+    if (dirPath == null) return null;
+    if (dirPath is Directory) return dirPath;
+    var p = dirPath.toString();
+    var dir = Directory(p);
+    return dir.existsSync() ? dir : null;
   }
 
-  static String _normalizeAddress(String address) {
-    address = address.trim();
-
-    if (address.isEmpty ||
-        address == '*' ||
-        address == '0' ||
-        address == '::' ||
-        address == '0:0:0:0:0:0:0:0') {
-      return '0.0.0.0';
-    }
-
-    if (address == 'local' ||
-        address == '1' ||
-        address == '127' ||
-        address == '::1' ||
-        address == '0:0:0:0:0:0:0:1') {
-      return 'localhost';
-    }
-
-    return address;
-  }
-
-  void _configureAPIRoot(APIRoot apiRoot) {
-    apiRoot.posApiRequestHandlers.add(_handleStaticFiles);
-  }
-
-  FutureOr<APIResponse<T>?> _handleStaticFiles<T>(
-      APIRoot apiRoot, APIRequest apiRequest) {
-    if (domainsRoots.isEmpty) return null;
-
-    for (var e in domainsRoots.entries) {
-      if (apiRequest.matchesHostname(e.key)) {
-        return _serveFile<T>(apiRequest, e.value);
-      }
-    }
-
-    return null;
-  }
-
-  FutureOr<APIResponse<T>> _serveFile<T>(
-      APIRequest apiRequest, Directory rootDirectory) {
-    var staticHandler = _getDirectoryStaticHandler(rootDirectory);
-
-    return staticHandler(apiRequest.toRequest())
-        .resolveMapped((response) => _APIResponseStaticFile<T>(response));
-  }
-
-  final Map<String, Handler> _directoriesStaticHandlers = <String, Handler>{};
-
-  Handler _getDirectoryStaticHandler(Directory rootDirectory) =>
-      _directoriesStaticHandlers.putIfAbsent(
-          rootDirectory.path, () => _createDirectoryHandler(rootDirectory));
-
-  Handler _createDirectoryHandler(Directory rootDirectory) {
-    rootDirectory = rootDirectory.absolute;
-
-    var pipeline = const Pipeline()
-        .addMiddleware(gzipMiddleware)
-        .addMiddleware(_staticFilesHeadersMiddleware);
-
-    var handler = pipeline.addHandler(
-        createStaticHandler(rootDirectory.path, defaultDocument: 'index.html'));
-    return handler;
-  }
-
-  Handler _staticFilesHeadersMiddleware(Handler innerHandler) => (request) {
-        return Future.sync(() => innerHandler(request)).then(
-            (response) => _configureStaticFilesHeaders(request, response));
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'version': version,
+        'address': address,
+        'port': port,
+        'securePort': securePort,
+        'domains': domainsRoots.map((k, v) => MapEntry(k, v.path)),
+        'letsEncrypt': letsEncrypt,
+        'letsEncryptProduction': letsEncryptProduction,
+        if (letsEncryptDirectory != null)
+          'letsEncryptDirectory': letsEncryptDirectory?.path,
+        'cookieless': cookieless,
+        'useSessionID': useSessionID,
+        'hotReload': hotReload,
+        'totalWorkers': totalWorkers,
+        'apiCacheControl': apiCacheControl,
+        'staticFilesCacheControl': staticFilesCacheControl,
+        'logToConsole': logToConsole,
+        if (args.isNotEmpty) 'args': args.toList(),
       };
 
-  Response _configureStaticFilesHeaders(Request request, Response response,
-      {Map<String, String>? headers}) {
-    headers ??= <String, String>{};
-
-    var statusCode = response.statusCode;
-    if (statusCode < 200 || statusCode > 299) {
-      return response.change(headers: headers);
-    }
-
-    headers[HttpHeaders.cacheControlHeader] = staticFilesCacheControl;
-
-    headers[HttpHeaders.serverHeader] ??= serverName;
-
-    return response.change(headers: headers);
+  factory APIServerConfig.fromJson(Map<String, dynamic> json) {
+    return APIServerConfig(
+      name: json['name'],
+      version: json['version'],
+      address: json['address'],
+      port: json['port'],
+      securePort: json['securePort'],
+      domains: json['domains'],
+      letsEncrypt: json['letsEncrypt'],
+      letsEncryptProduction: json['letsEncryptProduction'],
+      letsEncryptDirectory: json['letsEncryptDirectory'],
+      cookieless: json['cookieless'],
+      useSessionID: json['useSessionID'],
+      hotReload: json['hotReload'],
+      totalWorkers: json['totalWorkers'],
+      apiCacheControl: json['apiCacheControl'],
+      staticFilesCacheControl: json['staticFilesCacheControl'],
+      logToConsole: json['logToConsole'],
+      args: json['args'],
+    );
   }
+}
+
+/// Base class for an API Server.
+abstract class _APIServerBase extends APIServerConfig {
+  static final Map<Type, int> _idCounter = {};
+
+  static int _newID(Object o) {
+    var t = o.runtimeType;
+    var c = _idCounter[t] ?? 0;
+    ++c;
+    _idCounter[t] = c;
+    return c;
+  }
+
+  /// ID of this instance.
+  late final int id = _newID(this);
+
+  /// The API root of this server.
+  final APIRoot apiRoot;
+
+  _APIServerBase(
+    this.apiRoot, {
+    required super.name,
+    required super.version,
+    super.address,
+    super.port,
+    super.securePort,
+    super.domains,
+    super.letsEncrypt,
+    super.letsEncryptProduction,
+    super.letsEncryptDirectory,
+    super.allowRequestLetsEncryptCertificate,
+    super.hotReload,
+    super.totalWorkers,
+    super.cookieless,
+    super.useSessionID,
+    super.apiCacheControl,
+    super.staticFilesCacheControl,
+    super.logToConsole,
+  });
+
+  _APIServerBase.fromConfig(this.apiRoot, APIServerConfig apiServerConfig)
+      : super(
+          name: apiServerConfig.name,
+          version: apiServerConfig.version,
+          address: apiServerConfig.address,
+          port: apiServerConfig.port,
+          securePort: apiServerConfig.securePort,
+          domains: apiServerConfig.domainsRoots,
+          letsEncrypt: apiServerConfig.letsEncrypt,
+          letsEncryptProduction: apiServerConfig.letsEncryptProduction,
+          letsEncryptDirectory: apiServerConfig.letsEncryptDirectory,
+          allowRequestLetsEncryptCertificate:
+              apiServerConfig.allowRequestLetsEncryptCertificate,
+          hotReload: apiServerConfig.hotReload,
+          totalWorkers: apiServerConfig.totalWorkers,
+          cookieless: apiServerConfig.cookieless,
+          useSessionID: apiServerConfig.useSessionID,
+          apiCacheControl: apiServerConfig.apiCacheControl,
+          staticFilesCacheControl: apiServerConfig.staticFilesCacheControl,
+          logToConsole: apiServerConfig.logToConsole,
+        );
+
+  _APIServerBase.fromArgs(APIRoot apiRoot, List<String> args)
+      : this.fromConfig(apiRoot, APIServerConfig.fromArgs(args));
 
   /// The `server` header value.
   String get serverName => '$name/$version';
 
+  /// The host of [url];
   String get urlHost {
     switch (address) {
       case '0.0.0.0':
@@ -412,14 +662,10 @@ class APIServer {
   }
 
   /// The local URL of this server.
-  String get url {
-    return 'http://$urlHost:$port/';
-  }
+  String get url => 'http://$urlHost:$port/';
 
   /// The local `API-INFO` URL of this server.
-  String get apiInfoURL {
-    return 'http://$urlHost:$port/API-INFO';
-  }
+  String get apiInfoURL => 'http://$urlHost:$port/API-INFO';
 
   /// Returns `true` if the basic conditions for Let's Encrypt are configured.
   ///
@@ -433,178 +679,27 @@ class APIServer {
   /// Returns `true` if this servers is started.
   bool get isStarted => _started;
 
-  late HttpServer _httpServer;
-
-  HttpServer? _httpSecureServer;
-
   /// Starts this server.
   Future<bool> start() async {
     if (_started) return true;
     _started = true;
-
-    if (logToConsole) {
-      _log.handler.logToConsole();
-
-      _log.info("Activated `logToConsole` from `APIServer`.");
-    }
-
-    {
-      var isLoggingAll = LoggerHandler.getLogAllTo() != null;
-      var isLoggingToConsole = LoggerHandler.getLogToConsole();
-      var isLoggingError = LoggerHandler.root.getLogErrorTo() != null;
-      var isLoggingDB = LoggerHandler.root.getLogDbTo() != null;
-
-      _log.info(
-          "LOGGING> toConsole: $isLoggingToConsole ; all: $isLoggingAll ; error: $isLoggingError ; db: $isLoggingDB");
-    }
-
-    if (canUseLetsEncrypt) {
-      await _startLetsEncrypt();
-    } else {
-      await _startNormal();
-    }
-
-    if (hotReload) {
-      await APIHotReload.get().enable();
-    }
-
-    if (cookieless) {
-      _log.info('Cookieless Server: all cookies disabled! (NO `SESSIONID`)');
-    } else if (useSessionID) {
-      _log.info('Using `SESSIONID` cookies.');
-    }
-
-    _log.info('Started HTTP Server at: $address:$port');
-
-    _log.info('Initializing APIRoot `${apiRoot.name}`...');
-
-    return apiRoot.ensureInitialized().then((result) {
-      var modules = apiRoot.modules;
-      _log.info('Loaded modules: ${modules.map((e) => e.name).toList()}');
-
-      if (!result.ok) {
-        _log.severe('Error loading APIRoot: ${apiRoot.name}');
-      }
-
-      return result.ok;
-    });
+    var ok = await _startImpl();
+    return ok;
   }
 
-  Future<void> _startNormal() async {
-    _httpServer = await shelf_io.serve(_process, address, port);
-    _httpServer.autoCompress = true;
+  Future<bool> _startImpl();
 
-    _configureServer(_httpServer);
-  }
+  Completer<bool>? _stopped;
 
-  void _configureServer(HttpServer server) {
-    // Enable built-in [HttpServer] gzip:
-    server.autoCompress = true;
-  }
-
-  void _letsEncryptLogger(
-      String level, Object? message, Object? error, StackTrace? stackTrace) {
-    switch (level) {
-      case 'INFO':
-        {
-          _logLetsEncrypt.info(message, error, stackTrace);
-        }
-      case 'WARNING':
-        {
-          _logLetsEncrypt.warning(message, error, stackTrace);
-        }
-      case 'ERROR':
-        {
-          _logLetsEncrypt.severe(message, error, stackTrace);
-        }
-      default:
-        {
-          var logLevel = logging.Level.LEVELS.firstWhereOrNull(
-                  (e) => equalsIgnoreAsciiCase(e.name, level)) ??
-              logging.Level.INFO;
-
-          _logLetsEncrypt.log(logLevel, message, error, stackTrace);
-        }
-    }
-  }
-
-  Future<void> _startLetsEncrypt() async {
-    var letsEncryptDirectory = this.letsEncryptDirectory;
-
-    if (letsEncryptDirectory == null) {
-      throw StateError("Let's Encrypt directory not set!");
-    } else if (!letsEncryptDirectory.existsSync()) {
-      throw StateError(
-          "Let's Encrypt directory doesn't exists: $letsEncryptDirectory");
-    }
-
-    _log.info("Let's Encrypt directory: ${letsEncryptDirectory.path}");
-
-    final certificatesHandler = CertificatesHandlerIO(letsEncryptDirectory);
-
-    final LetsEncrypt letsEncrypt = LetsEncrypt(certificatesHandler,
-        production: letsEncryptProduction, log: _letsEncryptLogger);
-
-    var pipeline = const Pipeline().addMiddleware(_redirectToHttpsMiddleware);
-
-    var handler = pipeline.addHandler(_process);
-
-    final domains = this.domains;
-
-    var domain = domains.first;
-    var domainEmail = 'contact@$domain';
-
-    _log.info("Let's Encrypt domain: $domain");
-
-    if (!allowRequestLetsEncryptCertificate) {
-      _log.warning("NOT allowed to request Let's Encrypt certificates!");
-    }
-
-    var servers = await letsEncrypt.startSecureServer(
-      handler,
-      {domain: domainEmail},
-      port: port,
-      securePort: securePort,
-      bindingAddress: address,
-      requestCertificate: allowRequestLetsEncryptCertificate,
-    );
-
-    var server = servers[0]; // HTTP Server.
-    var secureServer = servers[1]; // HTTPS Server.
-
-    _httpServer = server;
-    _httpSecureServer = secureServer;
-
-    _configureServer(server);
-    _configureServer(secureServer);
-  }
-
-  Handler _redirectToHttpsMiddleware(Handler innerHandler) {
-    return (request) {
-      var requestedUri = request.requestedUri;
-
-      if (requestedUri.scheme == 'http' &&
-          !requestedUri.path.contains('/.well-known/acme-challenge/')) {
-        final domains = this.domains;
-        if (domains.contains(requestedUri.host)) {
-          var secureUri = requestedUri.replace(scheme: 'https');
-          return Response.seeOther(secureUri);
-        }
-      }
-
-      return innerHandler(request);
-    };
-  }
+  Completer<bool> get _stoppedCompleter => _stopped ??= Completer<bool>();
 
   /// Returns `true` if this server is closed.type
   ///
   /// A closed server can't processe new requests.
-  bool get isStopped => _stopped.isCompleted;
-
-  final Completer<bool> _stopped = Completer<bool>();
+  bool get isStopped => _stopped?.isCompleted ?? false;
 
   /// Returns a [Future] that completes when this server stops.
-  Future<bool> waitStopped() => _stopped.future;
+  Future<bool> waitStopped() => _stoppedCompleter.future;
 
   bool _stopping = false;
 
@@ -613,82 +708,160 @@ class APIServer {
     if (!_started || _stopping || isStopped) return;
     _stopping = true;
 
-    apiRoot.close();
+    await _stopImpl();
 
-    await _httpServer.close();
-
-    if (_httpSecureServer != null) {
-      await _httpSecureServer!.close();
-    }
-
-    _stopped.complete(true);
+    _stoppedCompleter.complete(true);
   }
 
-  FutureOr<Response> _process(Request request) {
-    APIRequest? apiRequest;
-    try {
-      return toAPIRequest(request).resolveMapped((apiReq) {
-        apiRequest = apiReq;
-        return _processAPIRequest(request, apiReq);
-      });
-    } catch (e, s) {
-      return _errorProcessing(request, apiRequest, e, s);
-    }
-  }
+  Future<void> _stopImpl();
+}
 
-  FutureOr<Response> _processAPIRequest(
-      Request request, APIRequest apiRequest) {
-    try {
-      if (apiRequest.method == APIRequestMethod.OPTIONS) {
-        return _processOPTIONSRequest(request, apiRequest);
-      } else {
-        return _processCall(request, apiRequest);
+/// An API HTTP Server
+class APIServer extends _APIServerBase {
+  APIServer(
+    super.apiRoot,
+    String address,
+    int port, {
+    super.name = 'Bones_API',
+    super.version = BonesAPI.VERSION,
+    super.securePort,
+    super.letsEncrypt,
+    super.letsEncryptProduction,
+    super.allowRequestLetsEncryptCertificate,
+    super.letsEncryptDirectory,
+    super.hotReload,
+    super.domains,
+    super.cookieless,
+    super.useSessionID,
+    super.totalWorkers,
+    super.apiCacheControl,
+    super.staticFilesCacheControl,
+    super.logToConsole,
+  }) : super(address: address, port: port);
+
+  APIServer.fromConfig(APIRoot apiRoot, APIServerConfig serverConfig)
+      : super.fromConfig(apiRoot, serverConfig);
+
+  APIServer.fromArgs(APIRoot apiRoot, List<String> args)
+      : super.fromArgs(apiRoot, args);
+
+  final List<APIServerWorker> _auxiliaryWorkers = [];
+
+  late final APIServerWorker _mainWorker;
+
+  @override
+  Future<bool> _startImpl() async {
+    var mainWorker = APIServerWorker(0, apiRoot,
+        address: address,
+        domains: domainsRoots,
+        apiCacheControl: apiCacheControl,
+        staticFilesCacheControl: staticFilesCacheControl,
+        letsEncryptDirectory: letsEncryptDirectory,
+        securePort: securePort,
+        useSessionID: useSessionID,
+        logToConsole: this.logToConsole,
+        port: port,
+        letsEncrypt: letsEncrypt,
+        letsEncryptProduction: letsEncryptProduction,
+        allowRequestLetsEncryptCertificate: allowRequestLetsEncryptCertificate,
+        name: name,
+        version: version,
+        hotReload: hotReload,
+        cookieless: cookieless,
+        totalWorkers: totalWorkers);
+
+    var auxiliaryWorkers = <APIServerWorker>[];
+    var totalAuxiliaryWorkers = totalWorkers - 1;
+
+    if (totalAuxiliaryWorkers >= 1) {
+      auxiliaryWorkers = List.generate(
+        totalAuxiliaryWorkers,
+        (i) => APIServerWorker(1 + i, apiRoot,
+            address: address,
+            domains: domainsRoots,
+            apiCacheControl: apiCacheControl,
+            staticFilesCacheControl: staticFilesCacheControl,
+            letsEncryptDirectory: letsEncryptDirectory,
+            securePort: securePort,
+            useSessionID: useSessionID,
+            logToConsole: this.logToConsole,
+            port: port,
+            letsEncrypt: letsEncrypt,
+            letsEncryptProduction: letsEncryptProduction,
+            allowRequestLetsEncryptCertificate:
+                allowRequestLetsEncryptCertificate,
+            name: name,
+            version: version,
+            hotReload: hotReload,
+            cookieless: cookieless,
+            totalWorkers: totalWorkers),
+      );
+    }
+
+    _mainWorker = mainWorker;
+
+    assert(_auxiliaryWorkers.isEmpty);
+    _auxiliaryWorkers.addAll(auxiliaryWorkers);
+
+    Map<APIServerWorker, (Isolate?, PortListener?, SendPort?, Future<bool>?)>?
+        workersSpawns;
+    if (totalAuxiliaryWorkers >= 1) {
+      _log.info("Spawning $totalAuxiliaryWorkers parallel workers...");
+
+      workersSpawns = await _auxiliaryWorkers
+          .map((e) => MapEntry(e, e.spawnIsolate()))
+          .toMapFromEntries()
+          .resolveAllValues();
+
+      _log.info("Spawned $totalAuxiliaryWorkers parallel workers.");
+    }
+
+    var mainOK = await mainWorker.start();
+
+    if (!mainOK) {
+      _log.severe("Can't start main `APIServerWorker`> $this");
+      return false;
+    }
+
+    if (workersSpawns != null) {
+      for (var e in workersSpawns.entries) {
+        var worker = e.key;
+        var workerSpawn = e.value;
+        var spawnPortListener = workerSpawn.$2;
+        var resumePort = workerSpawn.$3;
+
+        var ok = false;
+        if (spawnPortListener != null && resumePort != null) {
+          var confirmedAsync = spawnPortListener.next();
+          resumePort.send("resume");
+          var confirmed = await confirmedAsync;
+          ok = confirmed == 'confirm';
+        }
+
+        if (!ok) {
+          _log.severe(
+              "Can't start #${worker.workerIndex}/$totalWorkers `APIServerWorker`> $this");
+
+          return false;
+        }
       }
-    } catch (e, s) {
-      return _errorProcessing(request, apiRequest, e, s);
     }
+
+    return true;
   }
 
-  Response _errorProcessing(
-      Request request, APIRequest? apiRequest, Object error, StackTrace stack) {
-    var requestStr = apiRequest ?? _requestToString(request);
-
-    var message = 'ERROR processing request:\n\n$requestStr';
-    _log.severe(message, error, stack);
-
-    return Response.internalServerError(body: '$message\n\n$error\n$stack');
-  }
-
-  String _requestToString(Request request) {
-    var s = StringBuffer();
-    s.write('METHOD: ');
-    s.write(request.method);
-    s.write('\n');
-
-    s.write('URI: ');
-    s.write(request.requestedUri);
-    s.write('\n');
-
-    if (request.contentLength != null) {
-      s.write('Content-Length: ');
-      s.write(request.contentLength);
-      s.write('\n');
+  @override
+  Future<void> _stopImpl() async {
+    for (var worker in _auxiliaryWorkers) {
+      await worker.stop();
     }
 
-    s.write('HEADERS:\n');
-    for (var e in request.headers.entries) {
-      s.write('  - ');
-      s.write(e.key);
-      s.write(': ');
-      s.write(e.value);
-      s.write('\n');
-    }
-
-    return s.toString();
+    await _mainWorker.stop();
   }
 
   /// Converts a [request] to an [APIRequest].
-  FutureOr<APIRequest> toAPIRequest(Request request) {
+  static FutureOr<APIRequest> toAPIRequest(Request request,
+      {required bool cookieless, required bool useSessionID}) {
     var requestTime = DateTime.now();
 
     var method = parseAPIRequestMethod(request.method) ?? APIRequestMethod.GET;
@@ -791,7 +964,7 @@ class APIServer {
     });
   }
 
-  Map<String, String>? _parseCookies(Request request) {
+  static Map<String, String>? _parseCookies(Request request) {
     var headerCookies = request.headersAll['cookie'];
     if (headerCookies == null || headerCookies.isEmpty) return null;
 
@@ -814,7 +987,7 @@ class APIServer {
   static final MimeType _mimeTypeTextPlain =
       MimeType.parse(MimeType.textPlain)!;
 
-  Future<(MimeType, Object)?> _resolvePayload(Request request) {
+  static Future<(MimeType, Object)?> _resolvePayload(Request request) {
     var contentLength = request.contentLength;
 
     var contentMimeType = _resolveContentMimeType(request);
@@ -831,7 +1004,7 @@ class APIServer {
     }
   }
 
-  MimeType? _resolveContentMimeType(Request request) {
+  static MimeType? _resolveContentMimeType(Request request) {
     var contentType = request.headers[HttpHeaders.contentTypeHeader];
 
     var mimeType = MimeType.parse(contentType);
@@ -849,7 +1022,7 @@ class APIServer {
     return mimeType;
   }
 
-  MimeType? _resolveMimeTypeByExtension(String? path) {
+  static MimeType? _resolveMimeTypeByExtension(String? path) {
     if (path == null || path.isEmpty) return null;
 
     var idx = path.lastIndexOf('.');
@@ -859,7 +1032,7 @@ class APIServer {
     return MimeType.byExtension(ext, defaultAsApplication: false);
   }
 
-  Future<(MimeType, Object)?> _resolvePayloadFromString(
+  static Future<(MimeType, Object)?> _resolvePayloadFromString(
           MimeType mimeType, Request request) =>
       _loadPayloadString(mimeType, request).then((s) {
         if (s == null) return null;
@@ -874,7 +1047,8 @@ class APIServer {
         return (mimeType, payload);
       });
 
-  Future<String?> _loadPayloadString(MimeType mimeType, Request request) =>
+  static Future<String?> _loadPayloadString(
+          MimeType mimeType, Request request) =>
       request.read().toList().then((bs) {
         var allBytes = _loadPayloadBytes(bs);
 
@@ -887,14 +1061,14 @@ class APIServer {
         }
       });
 
-  Future<(MimeType, Uint8List)?> _resolvePayloadBytes(
+  static Future<(MimeType, Uint8List)?> _resolvePayloadBytes(
           MimeType mimeType, Request request) =>
       request.read().toList().then((bs) {
         var allBytes = _loadPayloadBytes(bs);
         return (mimeType, allBytes);
       });
 
-  Uint8List _loadPayloadBytes(List<List<int>> payloadBlocks) {
+  static Uint8List _loadPayloadBytes(List<List<int>> payloadBlocks) {
     Uint8List bytes;
 
     if (payloadBlocks.length == 1) {
@@ -928,7 +1102,7 @@ class APIServer {
 
   static final RegExp _regExpSpace = RegExp(r'\s+');
 
-  APICredential? _resolveCredential(Request request) {
+  static APICredential? _resolveCredential(Request request) {
     var headerAuthorization = request.headers.getIgnoreCase('Authorization');
     if (headerAuthorization == null) return null;
 
@@ -957,146 +1131,15 @@ class APIServer {
     return null;
   }
 
-  bool _isLocalAddress(String address) =>
+  static bool _isLocalAddress(String address) =>
       address == '127.0.0.1' ||
       address == '0.0.0.0' ||
       address == '::1' ||
       address == '::';
 
-  HttpConnectionInfo? _getConnectionInfo(Request request) {
+  static HttpConnectionInfo? _getConnectionInfo(Request request) {
     var val = request.context['shelf.io.connection_info'];
     return val is HttpConnectionInfo ? val : null;
-  }
-
-  FutureOr<Response> _processOPTIONSRequest(
-      Request request, APIRequest apiRequest) {
-    APIResponse apiResponse;
-
-    if (!apiRoot.acceptsRequest(apiRequest)) {
-      apiResponse = APIResponse.notFound();
-    } else {
-      apiResponse = APIResponse.ok('');
-    }
-
-    return _processAPIResponse(request, apiRequest, apiResponse);
-  }
-
-  FutureOr<Response> _processCall(Request request, APIRequest apiRequest) {
-    FutureOr<APIResponse> apiResponse;
-
-    try {
-      apiResponse = apiRoot.call(apiRequest);
-      if (apiResponse is Future<APIResponse>) {
-        apiResponse = apiResponse.catchError((e, s) {
-          return APIResponse.error(error: e, stackTrace: s);
-        });
-      }
-    } catch (e, s) {
-      apiResponse = APIResponse.error(error: e, stackTrace: s);
-    }
-
-    return apiResponse
-        .resolveMapped((res) => _processAPIResponse(request, apiRequest, res));
-  }
-
-  FutureOr<Response> _processAPIResponse(
-      Request request, APIRequest apiRequest, APIResponse apiResponse) {
-    setCORS(apiRequest, apiResponse);
-
-    if (apiResponse is _APIResponseStaticFile) {
-      return apiResponse.fileResponse;
-    }
-
-    var headers = <String, Object>{};
-
-    if (!apiResponse.hasCORS) {
-      apiResponse.setCORS(apiRequest);
-    }
-
-    if (apiResponse.requiresAuthentication) {
-      var type = apiResponse.authenticationType;
-      if (type == null || type.trim().isEmpty) {
-        type = 'Basic';
-      }
-
-      var realm = apiResponse.authenticationRealm;
-      if (realm == null || type.trim().isEmpty) {
-        realm = 'API';
-      }
-
-      headers[HttpHeaders.wwwAuthenticateHeader] = '$type realm="$realm"';
-    }
-
-    for (var e in apiResponse.headers.entries) {
-      var value = e.value;
-      if (value != null) {
-        headers[e.key] = value;
-      }
-    }
-
-    headers[HttpHeaders.serverHeader] ??= serverName;
-
-    if (apiRequest.newSession && !cookieless) {
-      var setSessionID = 'SESSIONID=${apiRequest.sessionID}';
-      headers.setMultiValue(HttpHeaders.setCookieHeader, setSessionID,
-          ignoreCase: true);
-    }
-
-    var authentication = apiRequest.authentication;
-    if (authentication != null) {
-      var tokenKey = authentication.tokenKey;
-
-      if (authentication.resumed ||
-          _needToSendHeaderXAccessToken(headers, tokenKey)) {
-        headers.setMultiValue('X-Access-Token', tokenKey, ignoreCase: true);
-      }
-    }
-
-    headers[HttpHeaders.cacheControlHeader] = apiCacheControl;
-
-    var retPayload = resolveBody(apiResponse.payload, apiResponse);
-
-    return retPayload.resolveMapped((payload) {
-      if (payload is APIResponse) {
-        var apiResponse2 = payload;
-        return resolveBody(apiResponse2.payload, apiResponse2)
-            .resolveMapped((payload2) {
-          var response = _sendAPIResponse(
-              request, apiRequest, apiResponse2, headers, payload2);
-          return _applyGzipEncoding(request, response);
-        });
-      } else {
-        var response = _sendAPIResponse(
-            request, apiRequest, apiResponse, headers, payload);
-        return _applyGzipEncoding(request, response);
-      }
-    });
-  }
-
-  FutureOr<Response> _applyGzipEncoding(
-      Request request, FutureOr<Response> response) {
-    if (!acceptsGzipEncoding(request)) {
-      return response;
-    } else {
-      return response.resolveMapped(gzipEncodeResponse);
-    }
-  }
-
-  bool _needToSendHeaderXAccessToken(
-      Map<String, Object> headers, String tokenKey) {
-    var headerAuthorization = headers.getFirstValue('authorization');
-    var notSentByAuthentication =
-        headerAuthorization == null || !headerAuthorization.contains(tokenKey);
-
-    var headerAccessToken =
-        headers.getMultiValue('x-access-token', ignoreCase: true);
-    var notSentByAccessToken =
-        headerAccessToken == null || !headerAccessToken.contains(tokenKey);
-
-    var needToSendHeaderXAccessToken =
-        notSentByAuthentication && notSentByAccessToken;
-
-    return needToSendHeaderXAccessToken;
   }
 
   static final String headerXAccessToken = "X-Access-Token";
@@ -1106,7 +1149,7 @@ class APIServer {
   static final String exposeHeaders =
       "Content-Length, Content-Type, Last-Modified, $headerXAccessToken, $headerXAccessTokenExpiration";
 
-  void setCORS(APIRequest request, APIResponse response) {
+  static void setCORS(APIRequest request, APIResponse response) {
     var origin = getOrigin(request);
 
     var localhost = false;
@@ -1140,7 +1183,7 @@ class APIServer {
         exposeHeaders;
   }
 
-  String getOrigin(APIRequest request) {
+  static String getOrigin(APIRequest request) {
     var origin = request.headers['origin'];
     if (origin != null) return origin;
 
@@ -1154,106 +1197,6 @@ class APIServer {
 
     origin = "http://localhost/";
     return origin;
-  }
-
-  FutureOr<Response> _sendAPIResponse(Request request, APIRequest apiRequest,
-      APIResponse apiResponse, Map<String, Object> headers, Object? payload) {
-    apiResponse.setMetric('API-call', apiRequest.elapsedTime);
-
-    var parsingDuration = apiRequest.parsingDuration;
-    if (parsingDuration != null) {
-      apiResponse.setMetric('API-request-parsing', parsingDuration);
-    }
-
-    apiResponse.stopAllMetrics();
-
-    var contentType = apiResponse.payloadMimeType;
-    if (contentType != null) {
-      headers[HttpHeaders.contentTypeHeader] = contentType.toString();
-    }
-
-    var etag = apiResponse.payloadETag;
-    if (etag != null) {
-      headers[HttpHeaders.etagHeader] = etag.toString();
-    }
-
-    var cacheControl = apiResponse.cacheControl;
-    if (cacheControl != null) {
-      headers[HttpHeaders.cacheControlHeader] = cacheControl.toString();
-    }
-
-    if (apiRequest.keepAlive && !apiResponse.isBadRequest) {
-      var timeout = apiResponse.keepAliveTimeout.inSeconds.clamp(0, 3600);
-      var max = apiResponse.keepAliveMaxRequests.clamp(0, 1000000);
-
-      headers[HttpHeaders.connectionHeader] = 'Keep-Alive';
-      headers['keep-alive'] = 'timeout=$timeout, max=$max';
-    }
-
-    headers['server-timing'] = resolveServerTiming(apiResponse.metrics);
-
-    if (cookieless) {
-      headers.remove(HttpHeaders.setCookieHeader);
-      headers['X-Cookieless-Server'] = 'Blocking all cookies';
-    }
-
-    switch (apiResponse.status) {
-      case APIResponseStatus.OK:
-        return Response.ok(payload, headers: headers);
-      case APIResponseStatus.NOT_FOUND:
-        return Response.notFound(payload, headers: headers);
-      case APIResponseStatus.NOT_MODIFIED:
-        {
-          headers.remove('content-length');
-          return Response.notModified(headers: headers);
-        }
-      case APIResponseStatus.UNAUTHORIZED:
-        {
-          var wwwAuthenticate =
-              headers.getAsString('WWW-Authenticate', ignoreCase: true);
-
-          if (wwwAuthenticate != null && wwwAuthenticate.isNotEmpty) {
-            return Response(401, body: payload, headers: headers);
-          } else {
-            return Response.forbidden(payload, headers: headers);
-          }
-        }
-      case APIResponseStatus.REDIRECT:
-        {
-          var location = apiResponse.payload;
-          if (location is! Uri) {
-            return Response(400, body: "Invalid redirect URL: $location");
-          }
-
-          var body =
-              "<html><body>Redirecting to: <a href='$location'>$location</a></body></html>";
-
-          headers[HttpHeaders.locationHeader] = location.toString();
-          headers[HttpHeaders.contentTypeHeader] = 'text/html';
-
-          return Response(307, body: body, headers: headers);
-        }
-      case APIResponseStatus.BAD_REQUEST:
-        return Response(400, body: payload, headers: headers);
-      case APIResponseStatus.ERROR:
-        {
-          var error = apiResponse.error ?? '';
-          var stackTrace = apiResponse.stackTrace;
-          var errorContent = stackTrace != null ? '$error\n$stackTrace' : error;
-
-          var retError = resolveBody(errorContent, apiResponse);
-
-          headers[HttpHeaders.contentTypeHeader] ??= 'text/plain';
-
-          return retError.resolveMapped((error) {
-            _log.severe('500 Internal Server Error', error, stackTrace);
-            return Response.internalServerError(body: error, headers: headers);
-          });
-        }
-      default:
-        return Response.notFound('NOT FOUND[${request.method}]: ${request.url}',
-            headers: headers);
-    }
   }
 
   /// Resolves a [payload] to a HTTP body.
@@ -1433,7 +1376,7 @@ class APIServer {
             '${(letsEncrypt ? (letsEncryptProduction ? ' @production' : ' @staging') : '')}, '
             'letsEncryptDirectory: ${letsEncryptDirectory?.path}';
 
-    return 'APIServer{ apiRoot: ${apiRoot.name}[${apiRoot.version}] (${apiRoot.runtimeTypeNameUnsafe}), address: $address, port: $port$secureStr, hotReload: $hotReload (${APIHotReload.get().isEnabled ? 'enabled' : 'disabled'}), cookieless: $cookieless, SESSIONID: $useSessionID, started: $isStarted, stopped: $isStopped$domainsStr }';
+    return 'APIServer{ apiRoot: ${apiRoot.name}[${apiRoot.version}] (${apiRoot.runtimeTypeNameUnsafe}), address: $address, port: $port$secureStr, totalWorkers: $totalWorkers, hotReload: $hotReload (${APIHotReload.get().isEnabled ? 'enabled' : 'disabled'}), cookieless: $cookieless, SESSIONID: $useSessionID, started: $isStarted, stopped: $isStopped$domainsStr }';
   }
 
   /// Creates an [APIServer] with [apiRoot].
@@ -1563,6 +1506,678 @@ class APIServer {
   }
 }
 
+final class APIServerWorker extends _APIServerBase {
+  static final _log = logging.Logger('APIServerWorker');
+
+  final int workerIndex;
+
+  bool get isMainWorker => workerIndex == 0;
+
+  bool get isAuxiliaryWorker => !isMainWorker;
+
+  APIServerWorker(
+    this.workerIndex,
+    super.apiRoot, {
+    required super.name,
+    required super.version,
+    super.address,
+    super.port,
+    super.securePort,
+    super.domains,
+    super.letsEncryptDirectory,
+    super.letsEncrypt,
+    super.letsEncryptProduction,
+    super.allowRequestLetsEncryptCertificate,
+    super.hotReload,
+    super.totalWorkers,
+    super.cookieless,
+    super.useSessionID,
+    super.apiCacheControl,
+    super.staticFilesCacheControl,
+    super.logToConsole,
+  }) {
+    _configureAPIRoot(apiRoot);
+  }
+
+  void _configureAPIRoot(APIRoot apiRoot) {
+    apiRoot.posApiRequestHandlers.add(_handleStaticFiles);
+  }
+
+  FutureOr<APIResponse<T>?> _handleStaticFiles<T>(
+      APIRoot apiRoot, APIRequest apiRequest) {
+    if (domainsRoots.isEmpty) return null;
+
+    for (var e in domainsRoots.entries) {
+      if (apiRequest.matchesHostname(e.key)) {
+        return _serveFile<T>(apiRequest, e.value);
+      }
+    }
+
+    return null;
+  }
+
+  FutureOr<APIResponse<T>> _serveFile<T>(
+      APIRequest apiRequest, Directory rootDirectory) {
+    var staticHandler = _getDirectoryStaticHandler(rootDirectory);
+
+    return staticHandler(apiRequest.toRequest())
+        .resolveMapped((response) => _APIResponseStaticFile<T>(response));
+  }
+
+  final Map<String, Handler> _directoriesStaticHandlers = <String, Handler>{};
+
+  Handler _getDirectoryStaticHandler(Directory rootDirectory) =>
+      _directoriesStaticHandlers.putIfAbsent(
+          rootDirectory.path, () => _createDirectoryHandler(rootDirectory));
+
+  Handler _createDirectoryHandler(Directory rootDirectory) {
+    rootDirectory = rootDirectory.absolute;
+
+    var pipeline = const Pipeline()
+        .addMiddleware(gzipMiddleware)
+        .addMiddleware(_staticFilesHeadersMiddleware);
+
+    var handler = pipeline.addHandler(
+        createStaticHandler(rootDirectory.path, defaultDocument: 'index.html'));
+    return handler;
+  }
+
+  Handler _staticFilesHeadersMiddleware(Handler innerHandler) => (request) {
+        return Future.sync(() => innerHandler(request)).then(
+            (response) => _configureStaticFilesHeaders(request, response));
+      };
+
+  Response _configureStaticFilesHeaders(Request request, Response response,
+      {Map<String, String>? headers}) {
+    headers ??= <String, String>{};
+
+    var statusCode = response.statusCode;
+    if (statusCode < 200 || statusCode > 299) {
+      return response.change(headers: headers);
+    }
+
+    headers[HttpHeaders.cacheControlHeader] = staticFilesCacheControl;
+
+    headers[HttpHeaders.serverHeader] ??= serverName;
+
+    return response.change(headers: headers);
+  }
+
+  bool get hasMultipleWorkers => totalWorkers > 1;
+
+  String get workerDebugName => 'APIServerWorker#$id';
+
+  Future<(Isolate?, PortListener?, SendPort?, Future<bool>?)>
+      spawnIsolate() async {
+    if (_started) {
+      return (null, null, null, null);
+    }
+
+    final workerDebugName = this.workerDebugName;
+
+    var spawnPort = ReceivePort('$workerDebugName:spawnPort');
+
+    var spawnPortListener = PortListener(spawnPort);
+
+    var resumePortAsync = spawnPortListener.next();
+
+    final isolate = await Isolate.spawn(
+      _isolateInit,
+      (worker: this, mainWorkerPort: spawnPort.sendPort),
+      debugName: workerDebugName,
+    );
+
+    var exitPort = ReceivePort();
+    var completer = Completer<bool>();
+    exitPort.listen((_) => completer.complete(true));
+    isolate.addOnExitListener(exitPort.sendPort);
+
+    SendPort resumePort = await resumePortAsync;
+
+    return (isolate, spawnPortListener, resumePort, completer.future);
+  }
+
+  static void _isolateInit(
+      ({APIServerWorker worker, SendPort mainWorkerPort}) params) async {
+    final worker = params.worker;
+    final mainWorkerPort = params.mainWorkerPort;
+
+    final workerDebugName = worker.workerDebugName;
+
+    var resumePort = ReceivePort('$workerDebugName:resumePort');
+
+    _log.info("Waiting main `APIServerWorker` to start...");
+
+    var resumeAsync = resumePort.first;
+    mainWorkerPort.send(resumePort.sendPort);
+    var resume = await resumeAsync;
+
+    assert(resume == 'resume');
+
+    await worker.start();
+
+    mainWorkerPort.send("confirm");
+  }
+
+  static const _logSectionOpen =
+      '\n<<<<<======================================================================<<<<<';
+  static const _logSectionClose =
+      '\n>>>>>======================================================================>>>>>';
+
+  late HttpServer _httpServer;
+
+  HttpServer? _httpSecureServer;
+
+  @override
+  Future<bool> _startImpl() async {
+    if (this.logToConsole) {
+      _log.handler.logToConsole();
+
+      _log.info("Activated `logToConsole` from `APIServer`.");
+    }
+
+    {
+      var isLoggingAll = LoggerHandler.getLogAllTo() != null;
+      var isLoggingToConsole = LoggerHandler.getLogToConsole();
+      var isLoggingError = LoggerHandler.root.getLogErrorTo() != null;
+      var isLoggingDB = LoggerHandler.root.getLogDbTo() != null;
+
+      _log.info(
+          "LOGGING> toConsole: $isLoggingToConsole ; all: $isLoggingAll ; error: $isLoggingError ; db: $isLoggingDB");
+    }
+
+    _log.info("Starting...$_logSectionOpen");
+
+    return _startImpl2().then((ok) {
+      _log.info("Started: ${ok ? 'OK' : 'Fail'}$_logSectionClose");
+      return ok;
+    });
+  }
+
+  Future<bool> _startImpl2() async {
+    if (isAuxiliaryWorker) {
+      DBAdapter.enableAuxiliaryMode();
+    }
+
+    if (canUseLetsEncrypt) {
+      await _startLetsEncrypt();
+    } else {
+      await _startNormal();
+    }
+
+    if (hotReload) {
+      await APIHotReload.get().enable();
+    }
+
+    if (cookieless) {
+      _log.info('Cookieless Server: all cookies disabled! (NO `SESSIONID`)');
+    } else if (useSessionID) {
+      _log.info('Using `SESSIONID` cookies.');
+    }
+
+    var workerInfo = totalWorkers > 1
+        ? '[${isMainWorker ? 'main' : 'auxiliary'} worker#$workerIndex/$totalWorkers]'
+        : '';
+
+    _log.info('Started HTTP Server$workerInfo at: $address:$port');
+
+    _log.info('Initializing APIRoot$workerInfo `${apiRoot.name}`...');
+
+    return apiRoot.ensureInitialized().then((result) {
+      var modules = apiRoot.modules;
+      _log.info('Loaded modules: ${modules.map((e) => e.name).toList()}');
+
+      if (!result.ok) {
+        _log.severe('Error loading APIRoot: ${apiRoot.name}');
+      }
+
+      return result.ok;
+    });
+  }
+
+  Future<void> _startNormal() async {
+    _httpServer = await shelf_io.serve(
+      _process,
+      address,
+      port,
+      shared: hasMultipleWorkers,
+    );
+
+    _configureServer(_httpServer);
+  }
+
+  void _configureServer(HttpServer server) {
+    // Enable built-in [HttpServer] gzip:
+    server.autoCompress = true;
+  }
+
+  void _letsEncryptLogger(
+      String level, Object? message, Object? error, StackTrace? stackTrace) {
+    switch (level) {
+      case 'INFO':
+        {
+          _logLetsEncrypt.info(message, error, stackTrace);
+        }
+      case 'WARNING':
+        {
+          _logLetsEncrypt.warning(message, error, stackTrace);
+        }
+      case 'ERROR':
+        {
+          _logLetsEncrypt.severe(message, error, stackTrace);
+        }
+      default:
+        {
+          var logLevel = logging.Level.LEVELS.firstWhereOrNull(
+                  (e) => equalsIgnoreAsciiCase(e.name, level)) ??
+              logging.Level.INFO;
+
+          _logLetsEncrypt.log(logLevel, message, error, stackTrace);
+        }
+    }
+  }
+
+  Future<void> _startLetsEncrypt() async {
+    var letsEncryptDirectory = this.letsEncryptDirectory;
+
+    if (letsEncryptDirectory == null) {
+      throw StateError("Let's Encrypt directory not set!");
+    } else if (!letsEncryptDirectory.existsSync()) {
+      throw StateError(
+          "Let's Encrypt directory doesn't exists: $letsEncryptDirectory");
+    }
+
+    _log.info("Let's Encrypt directory: ${letsEncryptDirectory.path}");
+
+    final certificatesHandler = CertificatesHandlerIO(letsEncryptDirectory);
+
+    final LetsEncrypt letsEncrypt = LetsEncrypt(certificatesHandler,
+        production: letsEncryptProduction, log: _letsEncryptLogger);
+
+    var pipeline = const Pipeline().addMiddleware(_redirectToHttpsMiddleware);
+
+    var handler = pipeline.addHandler(_process);
+
+    final domains = this.domains;
+
+    var domain = domains.first;
+    var domainEmail = 'contact@$domain';
+
+    _log.info("Let's Encrypt domain: $domain");
+
+    if (!allowRequestLetsEncryptCertificate) {
+      _log.warning("NOT allowed to request Let's Encrypt certificates!");
+    }
+
+    var servers = await letsEncrypt.startSecureServer(
+      handler,
+      {domain: domainEmail},
+      port: port,
+      securePort: securePort,
+      bindingAddress: address,
+      requestCertificate: allowRequestLetsEncryptCertificate,
+      shared: hasMultipleWorkers,
+    );
+
+    var server = servers[0]; // HTTP Server.
+    var secureServer = servers[1]; // HTTPS Server.
+
+    _httpServer = server;
+    _httpSecureServer = secureServer;
+
+    _configureServer(server);
+    _configureServer(secureServer);
+  }
+
+  Handler _redirectToHttpsMiddleware(Handler innerHandler) {
+    return (request) {
+      var requestedUri = request.requestedUri;
+
+      if (requestedUri.scheme == 'http' &&
+          !requestedUri.path.contains('/.well-known/acme-challenge/')) {
+        final domains = this.domains;
+        if (domains.contains(requestedUri.host)) {
+          var secureUri = requestedUri.replace(scheme: 'https');
+          return Response.seeOther(secureUri);
+        }
+      }
+
+      return innerHandler(request);
+    };
+  }
+
+  @override
+  Future<void> _stopImpl() async {
+    apiRoot.close();
+
+    await _httpServer.close();
+
+    if (_httpSecureServer != null) {
+      await _httpSecureServer!.close();
+    }
+  }
+
+  FutureOr<Response> _process(Request request) {
+    APIRequest? apiRequest;
+    try {
+      return APIServer.toAPIRequest(request,
+              cookieless: cookieless, useSessionID: useSessionID)
+          .resolveMapped((apiReq) {
+        apiRequest = apiReq;
+        return _processAPIRequest(request, apiReq);
+      });
+    } catch (e, s) {
+      return _errorProcessing(request, apiRequest, e, s);
+    }
+  }
+
+  FutureOr<Response> _processAPIRequest(
+      Request request, APIRequest apiRequest) {
+    try {
+      if (apiRequest.method == APIRequestMethod.OPTIONS) {
+        return _processOPTIONSRequest(request, apiRequest);
+      } else {
+        return _processCall(request, apiRequest);
+      }
+    } catch (e, s) {
+      return _errorProcessing(request, apiRequest, e, s);
+    }
+  }
+
+  Response _errorProcessing(
+      Request request, APIRequest? apiRequest, Object error, StackTrace stack) {
+    var requestStr = apiRequest ?? _requestToString(request);
+
+    var message = 'ERROR processing request:\n\n$requestStr';
+    _log.severe(message, error, stack);
+
+    return Response.internalServerError(body: '$message\n\n$error\n$stack');
+  }
+
+  String _requestToString(Request request) {
+    var s = StringBuffer();
+    s.write('METHOD: ');
+    s.write(request.method);
+    s.write('\n');
+
+    s.write('URI: ');
+    s.write(request.requestedUri);
+    s.write('\n');
+
+    if (request.contentLength != null) {
+      s.write('Content-Length: ');
+      s.write(request.contentLength);
+      s.write('\n');
+    }
+
+    s.write('HEADERS:\n');
+    for (var e in request.headers.entries) {
+      s.write('  - ');
+      s.write(e.key);
+      s.write(': ');
+      s.write(e.value);
+      s.write('\n');
+    }
+
+    return s.toString();
+  }
+
+  FutureOr<Response> _processOPTIONSRequest(
+      Request request, APIRequest apiRequest) {
+    APIResponse apiResponse;
+
+    if (!apiRoot.acceptsRequest(apiRequest)) {
+      apiResponse = APIResponse.notFound();
+    } else {
+      apiResponse = APIResponse.ok('');
+    }
+
+    return _processAPIResponse(request, apiRequest, apiResponse);
+  }
+
+  FutureOr<Response> _processCall(Request request, APIRequest apiRequest) {
+    FutureOr<APIResponse> apiResponse;
+
+    try {
+      apiResponse = apiRoot.call(apiRequest);
+      if (apiResponse is Future<APIResponse>) {
+        apiResponse = apiResponse.catchError((e, s) {
+          return APIResponse.error(error: e, stackTrace: s);
+        });
+      }
+    } catch (e, s) {
+      apiResponse = APIResponse.error(error: e, stackTrace: s);
+    }
+
+    return apiResponse
+        .resolveMapped((res) => _processAPIResponse(request, apiRequest, res));
+  }
+
+  FutureOr<Response> _processAPIResponse(
+      Request request, APIRequest apiRequest, APIResponse apiResponse) {
+    APIServer.setCORS(apiRequest, apiResponse);
+
+    if (apiResponse is _APIResponseStaticFile) {
+      return apiResponse.fileResponse;
+    }
+
+    var headers = <String, Object>{};
+
+    if (!apiResponse.hasCORS) {
+      apiResponse.setCORS(apiRequest);
+    }
+
+    if (apiResponse.requiresAuthentication) {
+      var type = apiResponse.authenticationType;
+      if (type == null || type.trim().isEmpty) {
+        type = 'Basic';
+      }
+
+      var realm = apiResponse.authenticationRealm;
+      if (realm == null || type.trim().isEmpty) {
+        realm = 'API';
+      }
+
+      headers[HttpHeaders.wwwAuthenticateHeader] = '$type realm="$realm"';
+    }
+
+    for (var e in apiResponse.headers.entries) {
+      var value = e.value;
+      if (value != null) {
+        headers[e.key] = value;
+      }
+    }
+
+    headers[HttpHeaders.serverHeader] ??= serverName;
+
+    if (apiRequest.newSession && !cookieless) {
+      var setSessionID = 'SESSIONID=${apiRequest.sessionID}';
+      headers.setMultiValue(HttpHeaders.setCookieHeader, setSessionID,
+          ignoreCase: true);
+    }
+
+    var authentication = apiRequest.authentication;
+    if (authentication != null) {
+      var tokenKey = authentication.tokenKey;
+
+      if (authentication.resumed ||
+          _needToSendHeaderXAccessToken(headers, tokenKey)) {
+        headers.setMultiValue('X-Access-Token', tokenKey, ignoreCase: true);
+      }
+    }
+
+    headers[HttpHeaders.cacheControlHeader] = apiCacheControl;
+
+    headers['X-APIServer-Worker'] = '$workerIndex/$totalWorkers';
+
+    var retPayload = APIServer.resolveBody(apiResponse.payload, apiResponse);
+
+    return retPayload.resolveMapped((payload) {
+      if (payload is APIResponse) {
+        var apiResponse2 = payload;
+        return APIServer.resolveBody(apiResponse2.payload, apiResponse2)
+            .resolveMapped((payload2) {
+          var response = _sendAPIResponse(
+              request, apiRequest, apiResponse2, headers, payload2);
+          return _applyGzipEncoding(request, response);
+        });
+      } else {
+        var response = _sendAPIResponse(
+            request, apiRequest, apiResponse, headers, payload);
+        return _applyGzipEncoding(request, response);
+      }
+    });
+  }
+
+  FutureOr<Response> _applyGzipEncoding(
+      Request request, FutureOr<Response> response) {
+    if (!acceptsGzipEncoding(request)) {
+      return response;
+    } else {
+      return response.resolveMapped(gzipEncodeResponse);
+    }
+  }
+
+  bool _needToSendHeaderXAccessToken(
+      Map<String, Object> headers, String tokenKey) {
+    var headerAuthorization = headers.getFirstValue('authorization');
+    var notSentByAuthentication =
+        headerAuthorization == null || !headerAuthorization.contains(tokenKey);
+
+    var headerAccessToken =
+        headers.getMultiValue('x-access-token', ignoreCase: true);
+    var notSentByAccessToken =
+        headerAccessToken == null || !headerAccessToken.contains(tokenKey);
+
+    var needToSendHeaderXAccessToken =
+        notSentByAuthentication && notSentByAccessToken;
+
+    return needToSendHeaderXAccessToken;
+  }
+
+  FutureOr<Response> _sendAPIResponse(Request request, APIRequest apiRequest,
+      APIResponse apiResponse, Map<String, Object> headers, Object? payload) {
+    apiResponse.setMetric('API-call', apiRequest.elapsedTime);
+
+    var parsingDuration = apiRequest.parsingDuration;
+    if (parsingDuration != null) {
+      apiResponse.setMetric('API-request-parsing', parsingDuration);
+    }
+
+    apiResponse.stopAllMetrics();
+
+    var contentType = apiResponse.payloadMimeType;
+    if (contentType != null) {
+      headers[HttpHeaders.contentTypeHeader] = contentType.toString();
+    }
+
+    var etag = apiResponse.payloadETag;
+    if (etag != null) {
+      headers[HttpHeaders.etagHeader] = etag.toString();
+    }
+
+    var cacheControl = apiResponse.cacheControl;
+    if (cacheControl != null) {
+      headers[HttpHeaders.cacheControlHeader] = cacheControl.toString();
+    }
+
+    if (apiRequest.keepAlive && !apiResponse.isBadRequest) {
+      var timeout = apiResponse.keepAliveTimeout.inSeconds.clamp(0, 3600);
+      var max = apiResponse.keepAliveMaxRequests.clamp(0, 1000000);
+
+      headers[HttpHeaders.connectionHeader] = 'Keep-Alive';
+      headers['keep-alive'] = 'timeout=$timeout, max=$max';
+    }
+
+    headers['server-timing'] =
+        APIServer.resolveServerTiming(apiResponse.metrics);
+
+    if (cookieless) {
+      headers.remove(HttpHeaders.setCookieHeader);
+      headers['X-Cookieless-Server'] = 'Blocking all cookies';
+    }
+
+    switch (apiResponse.status) {
+      case APIResponseStatus.OK:
+        return Response.ok(payload, headers: headers);
+      case APIResponseStatus.NOT_FOUND:
+        return Response.notFound(payload, headers: headers);
+      case APIResponseStatus.NOT_MODIFIED:
+        {
+          headers.remove('content-length');
+          return Response.notModified(headers: headers);
+        }
+      case APIResponseStatus.UNAUTHORIZED:
+        {
+          var wwwAuthenticate =
+              headers.getAsString('WWW-Authenticate', ignoreCase: true);
+
+          if (wwwAuthenticate != null && wwwAuthenticate.isNotEmpty) {
+            return Response(401, body: payload, headers: headers);
+          } else {
+            return Response.forbidden(payload, headers: headers);
+          }
+        }
+      case APIResponseStatus.REDIRECT:
+        {
+          var location = apiResponse.payload;
+          if (location is! Uri) {
+            return Response(400, body: "Invalid redirect URL: $location");
+          }
+
+          var body =
+              "<html><body>Redirecting to: <a href='$location'>$location</a></body></html>";
+
+          headers[HttpHeaders.locationHeader] = location.toString();
+          headers[HttpHeaders.contentTypeHeader] = 'text/html';
+
+          return Response(307, body: body, headers: headers);
+        }
+      case APIResponseStatus.BAD_REQUEST:
+        return Response(400, body: payload, headers: headers);
+      case APIResponseStatus.ERROR:
+        {
+          var error = apiResponse.error ?? '';
+          var stackTrace = apiResponse.stackTrace;
+          var errorContent = stackTrace != null ? '$error\n$stackTrace' : error;
+
+          var retError = APIServer.resolveBody(errorContent, apiResponse);
+
+          headers[HttpHeaders.contentTypeHeader] ??= 'text/plain';
+
+          return retError.resolveMapped((error) {
+            _log.severe('500 Internal Server Error', error, stackTrace);
+            return Response.internalServerError(body: error, headers: headers);
+          });
+        }
+      default:
+        return Response.notFound('NOT FOUND[${request.method}]: ${request.url}',
+            headers: headers);
+    }
+  }
+
+  @override
+  String toString() {
+    var domainsStr = domainsRoots.isNotEmpty
+        ? ', domains: [${domainsRoots.entries.map((e) {
+            var key = e.key;
+            var val = e.value;
+
+            return '${key is RegExp ? 'r/${key.pattern}/' : '`$key`'}=${val.path}';
+          }).join(' ; ')}]'
+        : '';
+
+    var secureStr = securePort < 10
+        ? ''
+        : ', securePort: $securePort, '
+            'letsEncrypt: $letsEncrypt'
+            '${(letsEncrypt ? (letsEncryptProduction ? ' @production' : ' @staging') : '')}, '
+            'letsEncryptDirectory: ${letsEncryptDirectory?.path}';
+
+    return 'APIServer{ apiRoot: ${apiRoot.name}[${apiRoot.version}] (${apiRoot.runtimeTypeNameUnsafe}), address: $address, port: $port$secureStr, hotReload: $hotReload (${APIHotReload.get().isEnabled ? 'enabled' : 'disabled'}), cookieless: $cookieless, SESSIONID: $useSessionID, started: $isStarted, stopped: $isStopped$domainsStr }';
+  }
+}
+
 extension _FileStatExtension on FileStat {
   bool get canWrite => modeString().contains('w');
 }
@@ -1583,5 +2198,48 @@ extension _APIRequestExtension on APIRequest {
     }
 
     return Request(method.name, requestedUri);
+  }
+}
+
+class PortListener {
+  final ReceivePort port;
+
+  late final StreamSubscription _subscription;
+
+  PortListener(this.port) {
+    _subscription = port.listen(_onData, cancelOnError: true);
+  }
+
+  Future<void> close() async {
+    await _subscription.cancel();
+  }
+
+  final ListQueue<Completer> _waitingQueue = ListQueue();
+
+  final ListQueue _unflushedQueue = ListQueue();
+
+  void _onData(o) {
+    if (_waitingQueue.isEmpty) {
+      _unflushedQueue.addLast(o);
+      return;
+    }
+
+    var completer = _waitingQueue.removeFirst();
+    if (!completer.isCompleted) {
+      completer.complete(o);
+    } else {
+      _unflushedQueue.addLast(o);
+    }
+  }
+
+  Future next() {
+    if (_unflushedQueue.isNotEmpty) {
+      var o = _unflushedQueue.removeFirst();
+      return Future.value(o);
+    }
+
+    var completer = Completer();
+    _waitingQueue.addLast(completer);
+    return completer.future;
   }
 }

--- a/lib/src/bones_api_server.dart
+++ b/lib/src/bones_api_server.dart
@@ -2031,6 +2031,8 @@ final class APIServerWorker extends _APIServerBase {
 
     headers['X-APIServer-Worker'] = '$workerIndex/$totalWorkers';
 
+    // headers['X-APIToken'] = apiRequest.credential?.token ?? '?';
+
     var retPayload = APIServer.resolveBody(apiResponse.payload, apiResponse);
 
     return retPayload.resolveMapped((payload) {

--- a/lib/src/bones_api_session.dart
+++ b/lib/src/bones_api_session.dart
@@ -176,7 +176,8 @@ class APISessionSet {
     });
   }
 
-  FutureOr<List<APISession>> expiredSessions(DateTime now) {
+  FutureOr<List<APISession>> expiredSessions([DateTime? now]) {
+    now ??= DateTime.now();
     return _resolveSharedSessions()
         .where((id, session) => session.isExpired(timeout, now: now))
         .resolveMapped((entries) => entries.map((e) => e.value).toList());

--- a/lib/src/bones_api_session.dart
+++ b/lib/src/bones_api_session.dart
@@ -1,6 +1,8 @@
 import 'dart:math';
 
+import 'package:async_extension/async_extension.dart';
 import 'package:collection/collection.dart';
+import 'package:shared_map/shared_map.dart';
 
 import 'bones_api_authentication.dart';
 import 'bones_api_base.dart';
@@ -82,12 +84,28 @@ class APISession {
 
 /// Handles a set of [APISession].
 class APISessionSet {
+  final SharedStoreField _sharedStoreField;
+
   /// The session timeout.
   final Duration timeout;
 
   late final Duration autoCheckInterval;
 
-  APISessionSet(this.timeout, {Duration? autoCheckInterval}) {
+  APISessionSet(this.timeout,
+      {Duration? autoCheckInterval,
+      APIRoot? apiRoot,
+      SharedStoreField? sharedStoreField,
+      SharedStoreReference? sharedStoreReference,
+      SharedStore? sharedStore,
+      String? sharedStoreID,
+      SharedStoreProviderSync? storeProvider})
+      : _sharedStoreField = SharedStoreField.tryFrom(
+                sharedStoreField: sharedStoreField,
+                sharedStoreReference: sharedStoreReference,
+                sharedStore: sharedStore ?? apiRoot?.sharedStore,
+                sharedStoreID: sharedStoreID,
+                storeProvider: storeProvider) ??
+            SharedStoreField.fromSharedStore(SharedStore.notShared()) {
     var autoCheckIntervalResolved = autoCheckInterval;
     if (autoCheckIntervalResolved == null) {
       autoCheckIntervalResolved =
@@ -98,38 +116,81 @@ class APISessionSet {
     }
 
     this.autoCheckInterval = autoCheckIntervalResolved;
+
+    // ignore: discarded_futures
+    _resolveSharedSessions();
   }
 
-  final Map<String, APISession> _sessions = <String, APISession>{};
+  SharedStore get sharedStore => _sharedStoreField.sharedStore;
 
-  int get length => _sessions.length;
+  String get sharedSessionsID => 'APISessionSet';
 
-  APISession? get(String sessionID) {
+  late final SharedMapField<String, APISession> _sharedSessionsField =
+      SharedMapField(sharedSessionsID, sharedStore: sharedStore);
+
+  static const Duration _cacheTimeout = Duration(seconds: 1);
+
+  static final Expando<SharedMap<String, APISession>> _sharedSessions =
+      Expando();
+
+  FutureOr<SharedMap<String, APISession>> _resolveSharedSessions() {
+    var sharedSessions = _sharedSessions[this];
+    if (sharedSessions != null) return sharedSessions;
+
+    return _sharedSessionsField
+        .sharedMapCached(timeout: _cacheTimeout)
+        .resolveMapped((sharedSessions) {
+      _sharedSessions[this] = sharedSessions;
+      return sharedSessions;
+    });
+  }
+
+  FutureOr<int> get length => _resolveSharedSessions().length();
+
+  FutureOr<APISession?> get(String sessionID) {
     autoCheckSessions();
-    return _sessions[sessionID];
+    return _resolveSharedSessions().get(sessionID);
   }
 
-  APISession? getMarkingAccess(String sessionID) {
-    var session = get(sessionID);
-    session?.markAccessTime();
-    return session;
+  FutureOr<APISession?> getMarkingAccess(String sessionID) {
+    return get(sessionID).resolveMapped((session) {
+      session?.markAccessTime();
+      return session;
+    });
   }
 
-  put(APISession session) {
+  FutureOr<APISession> put(APISession session) {
     autoCheckSessions();
-    return _sessions[session.id] = session;
+    return _resolveSharedSessions()
+        .put(session.id, session)
+        .resolveMapped((s) => s ?? session);
   }
 
-  List<APISession> expiredSessions(DateTime now) =>
-      _sessions.values.where((e) => e.isExpired(timeout, now: now)).toList();
+  FutureOr<APISession> getOrCreate(String sessionID) {
+    return getMarkingAccess(sessionID).resolveMapped((session) {
+      if (session == null) {
+        session = APISession(sessionID);
+        return put(session);
+      }
+      return session;
+    });
+  }
 
-  void checkSessions() {
+  FutureOr<List<APISession>> expiredSessions(DateTime now) {
+    return _resolveSharedSessions()
+        .where((id, session) => session.isExpired(timeout, now: now))
+        .resolveMapped((entries) => entries.map((e) => e.value).toList());
+  }
+
+  FutureOr<int> checkSessions() {
     var now = DateTime.now();
-    var expired = expiredSessions(now);
 
-    for (var e in expired) {
-      _sessions.remove(e.id);
-    }
+    return expiredSessions(now).resolveMapped((expired) {
+      var expiredIDs = expired.map((e) => e.id).toList();
+      return _resolveSharedSessions()
+          .removeAll(expiredIDs)
+          .resolveWithValue(expired.length);
+    });
   }
 
   DateTime _autoCheckSessionsLastTime = DateTime.now();
@@ -141,8 +202,9 @@ class APISessionSet {
     if (elapsedTime.inMilliseconds < autoCheckInterval.inMilliseconds) return;
     _autoCheckSessionsLastTime = now;
 
+    // ignore: discarded_futures
     checkSessions();
   }
 
-  void clear() => _sessions.clear();
+  FutureOr<int> clear() => _resolveSharedSessions().clear();
 }

--- a/lib/src/bones_api_sql_builder.dart
+++ b/lib/src/bones_api_sql_builder.dart
@@ -1550,6 +1550,10 @@ abstract mixin class SQLGenerator {
           ?.whereType<EntityField>()
           .toList();
 
+      if (entityFieldAnnotations != null && entityFieldAnnotations.hasHidden) {
+        continue;
+      }
+
       var columnName = normalizeColumnName(fieldName);
       var comment = '${fieldType.toString(withT: false)} $fieldName';
 

--- a/lib/src/bones_api_utils_isolate.dart
+++ b/lib/src/bones_api_utils_isolate.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:isolate';
+
+/// [ReceivePort] listener.
+class PortListener {
+  final ReceivePort port;
+
+  late final StreamSubscription _subscription;
+
+  PortListener(this.port) {
+    _subscription = port.listen(_onData, cancelOnError: true);
+  }
+
+  /// Closes this listener and cancels its [StreamSubscription].
+  Future<void> close() async {
+    await _subscription.cancel();
+  }
+
+  final ListQueue<Completer> _waitingQueue = ListQueue();
+
+  final ListQueue _unflushedQueue = ListQueue();
+
+  void _onData(o) {
+    if (_waitingQueue.isEmpty) {
+      _unflushedQueue.addLast(o);
+      return;
+    }
+
+    var completer = _waitingQueue.removeFirst();
+    if (!completer.isCompleted) {
+      completer.complete(o);
+    } else {
+      _unflushedQueue.addLast(o);
+    }
+  }
+
+  /// Waits and returns the next event value.
+  Future next() {
+    if (_unflushedQueue.isNotEmpty) {
+      var o = _unflushedQueue.removeFirst();
+      return Future.value(o);
+    }
+
+    var completer = Completer();
+    _waitingQueue.addLast(completer);
+    return completer.future;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A powerful API backend framework for Dart. It comes with a built-in HTTP Server, route handler, entity handler, SQL translator, and DB adapters.
-version: 1.5.0
+version: 1.5.1
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:
@@ -25,6 +25,7 @@ dependencies:
   project_template: ^1.0.2
   resource_portable: ^3.1.0
   docker_commander: ^2.1.5
+  args_simple: ^1.0.0
   shelf_letsencrypt: ^1.2.2
   shelf: ^1.4.1
   shelf_gzip: ^4.0.1
@@ -55,10 +56,12 @@ dev_dependencies:
   test: ^1.24.7
   pubspec: ^2.3.0
   dependency_validator: ^3.2.3
-  coverage: ^1.6.4
-  vm_service: ^11.10.0
+  coverage: ^1.7.1
+  vm_service: ^13.0.0
 
 #dependency_overrides:
+#  args_simple:
+#    path: ../args_simple
 #  graph_explorer:
 #    path: ../graph_explorer
 #  ascii_art_tree:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   statistics: ^1.0.26
   swiss_knife: ^3.1.5
   data_serializer: ^1.0.12
-  shared_map: ^1.0.8
+  shared_map: ^1.0.9
   graph_explorer: ^1.0.2
   ascii_art_tree: ^1.0.6
   map_history: ^1.0.3
@@ -26,7 +26,7 @@ dependencies:
   project_template: ^1.0.2
   resource_portable: ^3.1.0
   docker_commander: ^2.1.5
-  args_simple: ^1.0.0
+  args_simple: ^1.1.0
   shelf_letsencrypt: ^1.2.2
   shelf: ^1.4.1
   shelf_gzip: ^4.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   statistics: ^1.0.26
   swiss_knife: ^3.1.5
   data_serializer: ^1.0.12
-  shared_map: ^1.0.9
+  shared_map: ^1.0.10
   graph_explorer: ^1.0.2
   ascii_art_tree: ^1.0.6
   map_history: ^1.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   statistics: ^1.0.26
   swiss_knife: ^3.1.5
   data_serializer: ^1.0.12
-  shared_map: ^1.0.6
+  shared_map: ^1.0.8
   graph_explorer: ^1.0.2
   ascii_art_tree: ^1.0.6
   map_history: ^1.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   statistics: ^1.0.26
   swiss_knife: ^3.1.5
   data_serializer: ^1.0.12
+  shared_map: ^1.0.6
   graph_explorer: ^1.0.2
   ascii_art_tree: ^1.0.6
   map_history: ^1.0.3
@@ -60,6 +61,8 @@ dev_dependencies:
   vm_service: ^13.0.0
 
 #dependency_overrides:
+#  shared_map:
+#    path: ../shared_map
 #  args_simple:
 #    path: ../args_simple
 #  graph_explorer:

--- a/test/bones_api_security_test.dart
+++ b/test/bones_api_security_test.dart
@@ -225,7 +225,7 @@ void main() {
       }
     });
 
-    test('resumeAuthenticationByRequest', () {
+    test('resumeAuthenticationByRequest', () async {
       var apiSecurity = _MyAPISecurity(sharedStore: SharedStore.notShared());
 
       {
@@ -237,7 +237,7 @@ void main() {
         expect(request.authentication, isNotNull);
         expect(request.authentication!.username, equals('foo'));
 
-        var credential = apiSecurity.resolveSessionCredential(request);
+        var credential = await apiSecurity.resolveSessionCredential(request);
         expect(credential, isNotNull);
         expect(credential!.username, equals('foo'));
       }

--- a/test/bones_api_security_vm_test.dart
+++ b/test/bones_api_security_vm_test.dart
@@ -1,0 +1,154 @@
+@TestOn('vm')
+@Timeout(Duration(seconds: 180))
+// ignore_for_file: discarded_futures
+import 'dart:isolate';
+
+import 'package:bones_api/bones_api.dart';
+import 'package:shared_map/shared_map.dart';
+import 'package:test/test.dart';
+
+final fooSha256 =
+    '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae';
+final barSha256 =
+    'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9';
+
+final users = {'foo': fooSha256, 'bar': barSha256};
+final tokens = users.map((key, value) => MapEntry(value, key));
+
+void main() {
+  group('APISecurity', () {
+    test('authenticateByRequest (shared + Isolate)', () async {
+      final sharedStore = SharedStore.fromUUID();
+
+      var apiSecurity = _MyAPISecurity(sharedStore: sharedStore);
+
+      {
+        var request1 = APIRequest(APIRequestMethod.GET, 'foo');
+        request1.credential = APICredential('foo', passwordHash: 'foo');
+
+        expect(await apiSecurity.authenticateByRequest(request1), isNotNull);
+        expect(request1.authentication, isNotNull);
+        expect(request1.authentication!.username, equals('foo'));
+
+        var request2 = APIRequest(APIRequestMethod.GET, 'foo');
+        request2.credential = APICredential('bar', passwordHash: 'xxx');
+
+        expect(await apiSecurity.authenticateByRequest(request2), isNull);
+        expect(request2.authentication, isNull);
+      }
+
+      {
+        var request1 = APIRequest(APIRequestMethod.GET, 'foo');
+        request1.parameters['username'] = 'foo';
+        request1.parameters['password'] = 'foo';
+
+        expect(await apiSecurity.authenticateByRequest(request1), isNotNull);
+        expect(request1.authentication, isNotNull);
+        expect(request1.authentication!.username, equals('foo'));
+
+        var request2 = APIRequest(APIRequestMethod.GET, 'foo');
+        request2.parameters['username'] = 'foo';
+        request2.parameters['password'] = 'not_foo';
+
+        expect(await apiSecurity.authenticateByRequest(request2), isNull);
+        expect(request2.authentication, isNull);
+      }
+
+      {
+        var isolateOk = await Isolate.run<bool>(() async {
+          var request1 = APIRequest(APIRequestMethod.GET, 'foo');
+          request1.parameters['username'] = 'foo';
+          request1.parameters['password'] = 'foo';
+
+          var authentication1 =
+              await apiSecurity.authenticateByRequest(request1);
+          if (authentication1 == null) {
+            throw StateError("Null `authentication1`");
+          }
+
+          var requestAuthentication1 = request1.authentication;
+          if (requestAuthentication1 == null) {
+            throw StateError("Null `request1.authentication`");
+          }
+
+          if (requestAuthentication1.username != 'foo') {
+            throw StateError("`request1.authentication!.username` != 'foo'");
+          }
+
+          var request2 = APIRequest(APIRequestMethod.GET, 'foo');
+          request2.parameters['username'] = 'foo';
+          request2.parameters['password'] = 'not_foo';
+
+          var authentication2 =
+              await apiSecurity.authenticateByRequest(request2);
+          if (authentication2 != null) {
+            throw StateError("Expected null `authentication2`");
+          }
+
+          if (request2.authentication != null) {
+            throw StateError("Expected null `request2.authentication`");
+          }
+
+          var request3 = APIRequest(APIRequestMethod.GET, 'foo',
+              credential:
+                  APICredential('foo', token: requestAuthentication1.tokenKey));
+
+          var authentication3 =
+              await apiSecurity.authenticateByRequest(request3);
+          if (authentication3 == null) {
+            throw StateError("Null `authentication3`");
+          }
+
+          if (request3.authentication == null) {
+            throw StateError("Null `request3.authentication`");
+          }
+
+          return true;
+        });
+
+        expect(isolateOk, isTrue);
+      }
+    });
+  });
+}
+
+class _MyAPISecurity extends APISecurity {
+  _MyAPISecurity({super.sharedStore});
+
+  @override
+  String generateToken(String username) {
+    if (username == 'foo') {
+      return fooSha256;
+    } else if (username == 'bar') {
+      return barSha256;
+    }
+
+    return super.generateToken(username);
+  }
+
+  @override
+  FutureOr<APICredential> prepareCredential(APICredential credential) {
+    credential.usernameEntity = {
+      'username': credential.username,
+      if (credential.hasToken) 'token': credential.token,
+    };
+
+    return credential;
+  }
+
+  @override
+  FutureOr<bool> checkCredentialPassword(APICredential credential) {
+    var pass = users[credential.username];
+    var passOK = credential.checkPassword(pass);
+    return passOK;
+  }
+
+  @override
+  FutureOr<List<APIPermission>> getCredentialPermissions(
+      APICredential credential, List<APIPermission>? previousPermissions) {
+    return [
+      APIPermission('basic'),
+      if (credential.username.startsWith('admin')) APIPermission('admin'),
+    ];
+  }
+}

--- a/test/bones_api_session_test.dart
+++ b/test/bones_api_session_test.dart
@@ -1,0 +1,121 @@
+@TestOn('vm')
+@Timeout(Duration(seconds: 180))
+import 'dart:isolate';
+
+import 'package:bones_api/bones_api.dart';
+import 'package:shared_map/shared_map.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('APISessionSet', () {
+    final sharedStoreRef = SharedStore("t1").sharedReference();
+
+    test('basic (shared + Isolate)', () async {
+      final timeout = Duration(seconds: 3);
+      final timeout2 = Duration(seconds: 4);
+
+      var apiSessionSet = APISessionSet(timeout,
+          sharedStore: SharedStore.fromSharedReference(sharedStoreRef));
+
+      expect(apiSessionSet.length, equals(0));
+
+      expect(await apiSessionSet.get("abc"), isNull);
+
+      var isolate1 = await Isolate.run(() async {
+        var apiSessionSet2 =
+            APISessionSet(timeout, sharedStoreReference: sharedStoreRef);
+        return apiSessionSet2.get("abc");
+      });
+
+      expect(isolate1, isNull);
+
+      expect(apiSessionSet.length, equals(0));
+
+      var s1 = await apiSessionSet.getOrCreate("abc");
+      expect(s1.id, equals('abc'));
+
+      expect(apiSessionSet.length, equals(1));
+
+      var isolate2 = await Isolate.run(() async {
+        var apiSessionSet2 =
+            APISessionSet(timeout, sharedStoreReference: sharedStoreRef);
+        return apiSessionSet2.get("abc");
+      });
+
+      expect(apiSessionSet.length, equals(1));
+
+      expect(isolate2?.id, equals('abc'));
+
+      var s2 = await apiSessionSet.getMarkingAccess("abc");
+      expect(s2?.id, equals('abc'));
+
+      var isolate3 = await Isolate.run(() async {
+        var apiSessionSet2 =
+            APISessionSet(timeout, sharedStoreReference: sharedStoreRef);
+        return apiSessionSet2.getMarkingAccess("abc");
+      });
+
+      expect(isolate3?.id, equals('abc'));
+
+      expect(await apiSessionSet.expiredSessions(), equals([]));
+
+      var isolate4 = await Isolate.run(() async {
+        var apiSessionSet2 =
+            APISessionSet(timeout, sharedStoreReference: sharedStoreRef);
+        return apiSessionSet2.expiredSessions();
+      });
+
+      expect(isolate4, equals([]));
+
+      await Future.delayed(timeout2);
+
+      var expired1 = await apiSessionSet.expiredSessions();
+      expect(expired1.map((e) => e.id).toList(), equals(['abc']));
+
+      expect(await apiSessionSet.checkSessions(), equals(1));
+
+      expect(apiSessionSet.length, equals(0));
+      expect(await apiSessionSet.get("abc"), isNull);
+
+      var isolate5 = await Isolate.run(() async {
+        var apiSessionSet2 =
+            APISessionSet(timeout, sharedStoreReference: sharedStoreRef);
+        var s = await apiSessionSet2.getOrCreate("xyz");
+        var l = await apiSessionSet2.length;
+        return (s, l);
+      });
+
+      expect(isolate5.$1.id, equals('xyz'));
+      expect(isolate5.$2, equals(1));
+
+      expect(apiSessionSet.length, equals(1));
+
+      var s3 = await apiSessionSet.getMarkingAccess("xyz");
+      expect(s3?.id, equals('xyz'));
+
+      var isolate6 = await Isolate.run(() async {
+        var apiSessionSet2 =
+            APISessionSet(timeout, sharedStoreReference: sharedStoreRef);
+        var s1 = await apiSessionSet2.get("xyz");
+
+        await Future.delayed(timeout2);
+
+        var check = await apiSessionSet2.checkSessions();
+        var l = await apiSessionSet2.length;
+
+        var s2 = await apiSessionSet2.get("xyz");
+
+        return (s1, check, l, s2);
+      });
+
+      expect(isolate6.$1?.id, equals('xyz'));
+      expect(isolate6.$2, equals(1));
+      expect(isolate6.$3, equals(0));
+      expect(isolate6.$4, isNull);
+
+      expect(apiSessionSet.length, equals(0));
+      expect(await apiSessionSet.get("abc"), isNull);
+      expect(await apiSessionSet.get("xyz"), isNull);
+    });
+  });
+}

--- a/test/bones_api_test.dart
+++ b/test/bones_api_test.dart
@@ -221,7 +221,7 @@ void main() {
     });
 
     test('parseDomains', () async {
-      expect(APIServerConfig.parseDomains(MapEntry('', '')), isNull);
+      expect(APIServerConfig.parseDomains(MapEntry('', '')), isEmpty);
 
       expect(
           APIServerConfig.parseDomains(MapEntry('foo.com', '/var/www'))

--- a/test/bones_api_test.dart
+++ b/test/bones_api_test.dart
@@ -221,35 +221,36 @@ void main() {
     });
 
     test('parseDomains', () async {
-      expect(APIServer.parseDomains(MapEntry('', '')), isNull);
+      expect(APIServerConfig.parseDomains(MapEntry('', '')), isNull);
 
       expect(
-          APIServer.parseDomains(MapEntry('foo.com', '/var/www'))
-              ?.map((key, value) => MapEntry(key, value.path)),
+          APIServerConfig.parseDomains(MapEntry('foo.com', '/var/www'))
+              .map((key, value) => MapEntry(key, value.path)),
           equals({'foo.com': '/var/www'}));
 
       expect(
-          APIServer.parseDomains(MapEntry('foo.com', Directory('/var/www0')))
-              ?.map((key, value) => MapEntry(key, value.path)),
+          APIServerConfig.parseDomains(
+                  MapEntry('foo.com', Directory('/var/www0')))
+              .map((key, value) => MapEntry(key, value.path)),
           equals({'foo.com': '/var/www0'}));
 
       expect(
-          APIServer.parseDomains('foo.com=/var/www&bar.com=/var/www2')
-              ?.map((key, value) => MapEntry(key, value.path)),
+          APIServerConfig.parseDomains('foo.com=/var/www&bar.com=/var/www2')
+              .map((key, value) => MapEntry(key, value.path)),
           equals({'foo.com': '/var/www', 'bar.com': '/var/www2'}));
 
       expect(
-          APIServer.parseDomains(
+          APIServerConfig.parseDomains(
                   r'r/(\w+\.)?foo.com/=/var/www&bar.com=/var/www2')
-              ?.map((key, value) => MapEntry(key, value.path)),
+              .map((key, value) => MapEntry(key, value.path)),
           equals({
             RegExp(r'(\w+\.)?foo.com'): '/var/www',
             'bar.com': '/var/www2'
           }));
 
       expect(
-          APIServer.parseDomains('bar.com=/var/www2')
-              ?.map((key, value) => MapEntry(key, value.path)),
+          APIServerConfig.parseDomains('bar.com=/var/www2')
+              .map((key, value) => MapEntry(key, value.path)),
           equals({'bar.com': '/var/www2'}));
     });
 

--- a/test/bones_api_utils_isolate_test.dart
+++ b/test/bones_api_utils_isolate_test.dart
@@ -1,0 +1,49 @@
+import 'dart:isolate';
+
+import 'package:bones_api/src/bones_api_utils_isolate.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PortListener', () {
+    test('basic', () async {
+      var port = ReceivePort();
+
+      var portListener = PortListener(port);
+
+      var value1 = portListener.next();
+      port.sendPort.send(10);
+      expect(await value1, equals(10));
+
+      var value2 = portListener.next();
+      port.sendPort.send(20);
+      expect(await value2, equals(20));
+
+      var value3 = portListener.next();
+      var value4 = portListener.next();
+
+      port.sendPort.send(30);
+      expect(await value3, equals(30));
+
+      port.sendPort.send(40);
+      expect(await value4, equals(40));
+
+      var value5 = portListener.next();
+      var value6 = portListener.next();
+
+      port.sendPort.send(50);
+      port.sendPort.send(60);
+
+      expect(await value5, equals(50));
+      expect(await value6, equals(60));
+
+      port.sendPort.send(80);
+      port.sendPort.send(90);
+
+      var value8 = portListener.next();
+      var value9 = portListener.next();
+
+      expect(await value8, equals(80));
+      expect(await value9, equals(90));
+    });
+  });
+}

--- a/test/bones_api_utils_isolate_test.dart
+++ b/test/bones_api_utils_isolate_test.dart
@@ -1,3 +1,5 @@
+@TestOn('vm')
+@Timeout(Duration(seconds: 180))
 import 'dart:isolate';
 
 import 'package:bones_api/src/bones_api_utils_isolate.dart';


### PR DESCRIPTION


- new `APIServerConfig`:
  - Holds the configuration need for `APIServer` and `APIServerWorker`.
  - Can be created from command-line arguments or a JSON object.

- Created an abstract base class `_APIServerBase` for  `APIServer` and `APIServerWorker`.
  - `start` and `stop` methods, delegating to `startImpl` and `stopImpl`.

- `APIServer`
  - Support for spawning auxiliary workers in separate isolates when needed.
  - Starting and stopping of auxiliary `APIServerWorker` instances using isolates. Main worker starts normally.

- New `APIServerWorker` to handle multi-worker `APIServer`.

- `APIRoot:`
  - Added `isIsolateCopy`.

- `DBAdapterCapability`:
  - Added `multiIsolateSupport`;

- `DBAdapter`
  - Added `auxiliaryMode` and `enableAuxiliaryMode`.
  - `DBSQLMemoryAdapter` and `DBObjectMemoryAdapter` don't support `auxiliaryMode`, since they don't support `multiIsolateSupport`.

- `SQLGenerator.generateCreateTableSQL`: skip annotated hidden fields.

- args_simple: ^1.0.0
- coverage: ^1.7.1
- vm_service: ^13.0.0
