### PR TITLE
v1.5.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.12
+
+- `APIServerConfig`:
+  - Added properties: `cacheStaticFilesResponses`, `staticFilesCacheMaxMemorySize` and `staticFilesCacheMaxContentLength`.
+
 ## 1.5.11
 
 - New `APIServerResponseCache`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - `APIServerConfig`:
   - Added properties: `cacheStaticFilesResponses`, `staticFilesCacheMaxMemorySize` and `staticFilesCacheMaxContentLength`.
+- `APIConfig`:
+  - `getAs` and `getPath`: also tries to parse the value to the returned type.
 
 ## 1.5.11
 

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -42,7 +42,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.5.11';
+  static const String VERSION = '1.5.12';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_server.dart
+++ b/lib/src/bones_api_server.dart
@@ -1449,7 +1449,7 @@ class APIServer extends _APIServerBase {
             '${(letsEncrypt ? (letsEncryptProduction ? ' @production' : ' @staging') : '')}, '
             'letsEncryptDirectory: ${letsEncryptDirectory?.path}';
 
-    return 'APIServer{ apiRoot: ${apiRoot.name}[${apiRoot.version}] (${apiRoot.runtimeTypeNameUnsafe}), address: $address, port: $port$secureStr, totalWorkers: $totalWorkers, hotReload: $hotReload (${APIHotReload.get().isEnabled ? 'enabled' : 'disabled'}), cookieless: $cookieless, SESSIONID: $useSessionID, started: $isStarted, stopped: $isStopped$domainsStr }';
+    return 'APIServer{ apiRoot: ${apiRoot.name}[${apiRoot.version}] (${apiRoot.runtimeTypeNameUnsafe}), address: $address, port: $port$secureStr, totalWorkers: $totalWorkers, cacheStaticFilesResponses: $cacheStaticFilesResponses, hotReload: $hotReload (${APIHotReload.get().isEnabled ? 'enabled' : 'disabled'}), cookieless: $cookieless, SESSIONID: $useSessionID, started: $isStarted, stopped: $isStopped$domainsStr }';
   }
 
   /// Creates an [APIServer] with [apiRoot].

--- a/lib/src/bones_api_server.dart
+++ b/lib/src/bones_api_server.dart
@@ -2428,7 +2428,7 @@ final class APIServerWorker extends _APIServerBase {
             '${(letsEncrypt ? (letsEncryptProduction ? ' @production' : ' @staging') : '')}, '
             'letsEncryptDirectory: ${letsEncryptDirectory?.path}';
 
-    return 'APIServer{ apiRoot: ${apiRoot.name}[${apiRoot.version}] (${apiRoot.runtimeTypeNameUnsafe}), address: $address, port: $port$secureStr, hotReload: $hotReload (${APIHotReload.get().isEnabled ? 'enabled' : 'disabled'}), cookieless: $cookieless, SESSIONID: $useSessionID, started: $isStarted, stopped: $isStopped$domainsStr }';
+    return 'APIServerWorker{ apiRoot: ${apiRoot.name}[${apiRoot.version}] (${apiRoot.runtimeTypeNameUnsafe}), address: $address, port: $port$secureStr, cacheStaticFilesResponses: $cacheStaticFilesResponses, hotReload: $hotReload (${APIHotReload.get().isEnabled ? 'enabled' : 'disabled'}), cookieless: $cookieless, SESSIONID: $useSessionID, started: $isStarted, stopped: $isStopped$domainsStr }';
   }
 }
 

--- a/lib/src/bones_api_server_cache.dart
+++ b/lib/src/bones_api_server_cache.dart
@@ -475,9 +475,13 @@ class APIServerResponseCache {
   }
 
   @override
-  String toString() {
-    return 'APIServerResponseCache{maxContentLength: $maxContentLength, maxMemorySize: $maxMemorySize, fileStatTimeout: ${fileStatTimeout.asBestUnit}, cachedResponses: ${_cachedResponses.length}, totalCachedResponsesMemorySize: $_totalCachedResponsesMemorySize}';
-  }
+  String toString() => 'APIServerResponseCache{ '
+      'maxContentLength: ${maxContentLength.asBestUnit}, '
+      'maxMemorySize: ${maxMemorySize.asBestUnit}, '
+      'fileStatTimeout: ${fileStatTimeout.asBestUnit}, '
+      'cachedResponses: ${_cachedResponses.length}, '
+      'totalMemorySize: $_totalCachedResponsesMemorySize '
+      '}';
 }
 
 class _CachedResponseKey {

--- a/lib/src/bones_api_server_cache.dart
+++ b/lib/src/bones_api_server_cache.dart
@@ -22,22 +22,24 @@ const _headerAPIServerCache = 'X-API-Server-Cache';
 class APIServerResponseCache {
   static const int defaultMaxContentLength = 1024 * 1024 * 10;
 
-  /// The maximum `Content-Length` to cache.
+  /// The maximum `Content-Length` allowed for a cached [Response].
   final int maxContentLength;
 
   static const int defaultMaxMemorySize = 1024 * 1024 * 50;
 
-  /// The maximum cache memory size.
+  /// The maximum memory size for storing all cached [Response]s.
   final int maxMemorySize;
 
   /// The timeout of a resolved [File.stat].
   final Duration fileStatTimeout;
 
   APIServerResponseCache({
-    this.maxContentLength = defaultMaxContentLength,
-    this.maxMemorySize = defaultMaxMemorySize,
+    int maxContentLength = defaultMaxContentLength,
+    int maxMemorySize = defaultMaxMemorySize,
     this.fileStatTimeout = _FileStat.defaultStatTimeout,
-  });
+  })  : maxContentLength = maxContentLength.clamp(0, 1024 * 1024 * 1024 * 8),
+        maxMemorySize =
+            maxMemorySize.clamp(1024 * 1024, 1024 * 1024 * 1024 * 32);
 
   final Map<_CachedResponseKey, Object> _cachedResponses = {};
 
@@ -470,6 +472,11 @@ class APIServerResponseCache {
       all.addAll(chunk);
     }
     return all;
+  }
+
+  @override
+  String toString() {
+    return 'APIServerResponseCache{maxContentLength: $maxContentLength, maxMemorySize: $maxMemorySize, fileStatTimeout: ${fileStatTimeout.asBestUnit}, cachedResponses: ${_cachedResponses.length}, totalCachedResponsesMemorySize: $_totalCachedResponsesMemorySize}';
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A powerful API backend framework for Dart. It comes with a built-in HTTP Server, route handler, entity handler, SQL translator, and DB adapters.
-version: 1.5.11
+version: 1.5.12
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:


### PR DESCRIPTION

 - `APIServerConfig`:
   - Added properties: `cacheStaticFilesResponses`, `staticFilesCacheMaxMemorySize` and `staticFilesCacheMaxContentLength`.
 - `APIConfig`:
   - `getAs` and `getPath`: also tries to parse the value to the returned type.