### PR TITLE
v1.5.21 - hex payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.21
+
+- `APIRouteBuilder`:
+  - `_resolveRequestParameterValueAsBytes`: allow `hex:...` format.
+
 ## 1.5.20 
 
 - Better error message for null `getRepositoryAdapterByTableName` and `getEntityRepositoryByType`.

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -42,7 +42,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.5.20';
+  static const String VERSION = '1.5.21';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_module.dart
+++ b/lib/src/bones_api_module.dart
@@ -814,6 +814,16 @@ class APIRouteBuilder<M extends APIModule> {
       var data = value.asUint8List;
       return data;
     } else if (value is String) {
+      if (value.startsWith("hex:")) {
+        var hexData = value.substring(4);
+        try {
+          var data = hex.decode(hexData);
+          return data;
+        } catch (_) {
+          // not a HEX data:
+        }
+      }
+
       var dataUrl = DataURLBase64.parse(value);
       if (dataUrl != null) {
         return dataUrl.payloadArrayBuffer;
@@ -832,6 +842,8 @@ class APIRouteBuilder<M extends APIModule> {
       } catch (_) {
         // not a HEX data:
       }
+
+      return utf8.encode(value);
     }
 
     return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A powerful API backend framework for Dart. It comes with a built-in HTTP Server, route handler, entity handler, SQL translator, and DB adapters.
-version: 1.5.20
+version: 1.5.21
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:

--- a/test/bones_api_test.reflection.g.dart
+++ b/test/bones_api_test.reflection.g.dart
@@ -437,7 +437,8 @@ class MyInfoModule$reflection extends ClassReflection<MyInfoModule>
     'initialize',
     'initializeDependencies',
     'resolveRoute',
-    'toUpperCase'
+    'toUpperCase',
+    'withPayload'
   ];
 
   @override
@@ -540,6 +541,24 @@ class MyInfoModule$reflection extends ClassReflection<MyInfoModule>
             obj,
             false,
             const <__PR>[__PR(__TR.tString, 'msg', false, true)],
+            null,
+            null,
+            null);
+      case 'withpayload':
+        return MethodReflection<MyInfoModule, FutureOr<APIResponse<String>>>(
+            this,
+            MyInfoModule,
+            'withPayload',
+            __TR<FutureOr<APIResponse<String>>>(FutureOr, <__TR>[
+              __TR<APIResponse<String>>(APIResponse, <__TR>[__TR.tString])
+            ]),
+            false,
+            (o) => o!.withPayload,
+            obj,
+            false,
+            const <__PR>[
+              __PR(__TR<Uint8List>(Uint8List), 'payload', true, true)
+            ],
             null,
             null,
             null);
@@ -895,6 +914,17 @@ extension MyInfoModuleProxy$reflectionProxy on MyInfoModuleProxy {
         'toUpperCase',
         <String, dynamic>{
           'msg': msg,
+        },
+        __TR.tFutureString);
+    return __retFut$<String>(ret);
+  }
+
+  Future<String> withPayload(Uint8List? payload) {
+    var ret = onCall(
+        this,
+        'withPayload',
+        <String, dynamic>{
+          'payload': payload,
         },
         __TR.tFutureString);
     return __retFut$<String>(ret);


### PR DESCRIPTION
- `APIRouteBuilder`:
  - `_resolveRequestParameterValueAsBytes`: allow `hex:...` format.