### PR TITLE
v1.5.22 - check enum constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.5.22
+
+- `DBAdapterCapability`:
+  - Added `constraintSupport`.
+- `TableScheme`:
+  - Added `constraints`.
+- New `TableConstraint`, `TablePrimaryKeyConstraint` and `TableEnumConstraint`.
+- `SQLGenerator`:
+  - Added `generateAddEnumConstraintAlterTableSQL`.
+- `MapAsCacheExtension`:
+  - Added internal `_checkCachedEntry` to handle `TimedMap.checkEntry`.
+
 ## 1.5.21
 
 - `APIRouteBuilder`:

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -42,7 +42,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.5.21';
+  static const String VERSION = '1.5.22';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_entity_db.dart
+++ b/lib/src/bones_api_entity_db.dart
@@ -43,6 +43,9 @@ class DBAdapterCapability implements WithRuntimeTypeNameSafe {
   /// `true` if the DB fully supports [transactions] and [transactionAbort].
   bool get fullTransaction => transactions && transactionAbort;
 
+  /// `true` if the DB supports constraints.
+  final bool constraintSupport;
+
   /// `true` if the [DBAdapter] supports execution in multiple [Isolate]s.
   /// - If an adapter tries to initialize inside an auxiliary [Isolate] ([DBAdapter.auxiliaryMode]), it will fail.
   final bool multiIsolateSupport;
@@ -51,11 +54,12 @@ class DBAdapterCapability implements WithRuntimeTypeNameSafe {
     required this.dialect,
     required this.transactions,
     required this.transactionAbort,
+    required this.constraintSupport,
     required this.multiIsolateSupport,
   });
 
   String get info =>
-      'transactions: $transactions, transactionAbort: $transactionAbort, multiIsolateSupport: $multiIsolateSupport';
+      'transactions: $transactions, transactionAbort: $transactionAbort, constraintSupport: $constraintSupport, multiIsolateSupport: $multiIsolateSupport';
 
   @override
   String get runtimeTypeNameSafe => 'DBAdapterCapability';

--- a/lib/src/bones_api_entity_db_memory.dart
+++ b/lib/src/bones_api_entity_db_memory.dart
@@ -105,6 +105,7 @@ class DBSQLMemoryAdapter extends DBSQLAdapter<DBSQLMemoryAdapterContext>
               transactions: true,
               transactionAbort: true,
               tableSQL: false,
+              constraintSupport: false,
               multiIsolateSupport: false),
         ) {
     boot();

--- a/lib/src/bones_api_entity_db_mysql.dart
+++ b/lib/src/bones_api_entity_db_mysql.dart
@@ -104,6 +104,7 @@ class DBMySQLAdapter extends DBSQLAdapter<DBMySqlConnectionWrapper>
               transactions: true,
               transactionAbort: true,
               tableSQL: true,
+              constraintSupport: false,
               multiIsolateSupport: true),
         ) {
     boot();

--- a/lib/src/bones_api_entity_db_object_directory.dart
+++ b/lib/src/bones_api_entity_db_object_directory.dart
@@ -91,6 +91,7 @@ class DBObjectDirectoryAdapter
               dialect: DBDialect('object'),
               transactions: true,
               transactionAbort: true,
+              constraintSupport: false,
               multiIsolateSupport: true),
         ) {
     boot();

--- a/lib/src/bones_api_entity_db_object_gcs.dart
+++ b/lib/src/bones_api_entity_db_object_gcs.dart
@@ -105,6 +105,7 @@ class DBObjectGCSAdapter extends DBObjectAdapter<DBObjectGCSAdapterContext> {
               dialect: DBDialect('object'),
               transactions: true,
               transactionAbort: true,
+              constraintSupport: false,
               multiIsolateSupport: true),
         ) {
     boot();
@@ -243,7 +244,7 @@ class DBObjectGCSAdapter extends DBObjectAdapter<DBObjectGCSAdapterContext> {
 
   @override
   String getConnectionURL(DBObjectGCSAdapterContext connection) =>
-      'object.directory://${connection.id}';
+      'object.gcs://${connection.id}';
 
   int _connectionCount = 0;
 

--- a/lib/src/bones_api_entity_db_object_memory.dart
+++ b/lib/src/bones_api_entity_db_object_memory.dart
@@ -90,6 +90,7 @@ class DBObjectMemoryAdapter
               dialect: DBDialect('object'),
               transactions: true,
               transactionAbort: true,
+              constraintSupport: false,
               multiIsolateSupport: false),
         ) {
     boot();

--- a/lib/src/bones_api_utils_collections.dart
+++ b/lib/src/bones_api_utils_collections.dart
@@ -5,6 +5,7 @@ import 'package:collection/collection.dart';
 
 import 'bones_api_entity.dart';
 import 'bones_api_entity_reference.dart';
+import 'bones_api_utils_timedmap.dart';
 
 /// Helper to work with positional fields.
 class PositionalFields {
@@ -351,14 +352,25 @@ extension IterableEnumExtension<E extends Enum> on Iterable<E> {
 
 /// Extension that ads cached methods to a [Map].
 extension MapAsCacheExtension<K, V> on Map<K, V> {
+  void _checkCachedEntry(K key) {
+    var self = this;
+    if (self is TimedMap<K, V>) {
+      self.checkEntry(key);
+    }
+  }
+
   /// Returns [key] value or computes it and caches it.
   /// See [checkCacheLimit] and [getCachedAsync].
   V getCached(K key, V Function() computer, {int? cacheLimit}) {
+    _checkCachedEntry(key);
     checkCacheLimit(cacheLimit);
+
     return putIfAbsent(key, computer);
   }
 
   V? getCachedNullable(K key, V? Function() computer, {int? cacheLimit}) {
+    _checkCachedEntry(key);
+
     var cached = this[key];
     if (cached != null) return cached;
 
@@ -375,6 +387,8 @@ extension MapAsCacheExtension<K, V> on Map<K, V> {
   /// See [checkCacheLimit] and [getCachedAsync].
   FutureOr<V> getCachedAsync(K key, FutureOr<V> Function() computer,
       {int? cacheLimit}) {
+    _checkCachedEntry(key);
+
     var cached = this[key];
     if (cached != null) return cached;
 
@@ -388,6 +402,8 @@ extension MapAsCacheExtension<K, V> on Map<K, V> {
 
   FutureOr<V?> getCachedAsyncNullable(K key, FutureOr<V?> Function() computer,
       {int? cacheLimit}) {
+    _checkCachedEntry(key);
+
     var cached = this[key];
     if (cached != null) return cached;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A powerful API backend framework for Dart. It comes with a built-in HTTP Server, route handler, entity handler, SQL translator, and DB adapters.
-version: 1.5.21
+version: 1.5.22
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:


### PR DESCRIPTION
- `DBAdapterCapability`:
  - Added `constraintSupport`.
- `TableScheme`:
  - Added `constraints`.
- New `TableConstraint`, `TablePrimaryKeyConstraint` and `TableEnumConstraint`.
- `SQLGenerator`:
  - Added `generateAddEnumConstraintAlterTableSQL`.
- `MapAsCacheExtension`:
  - Added internal `_checkCachedEntry` to handle `TimedMap.checkEntry`.