### PR TITLE
v1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.6.5
+
+- `EntityAccessRules`:
+  - Fix `toJsonEncodable` to allow rules to be applied to sub-entities. 
+
+- `APIResponse` extension on `Future` and `FutureOr`:
+  - Added `payloadAsyncOr`.
+
+- async_extension: ^1.2.7
+- reflection_factory: ^2.3.1
+- postgres: ^2.6.4
+- googleapis_auth: ^1.5.0
+
 ## 1.6.4
 
 - `EntityReference`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - `APIResponse` extension on `Future` and `FutureOr`:
   - Added `payloadAsyncOr`.
 
+- `LoggerHandler`:
+  - `flushMessages`: added parameter `delay`.
+
 - async_extension: ^1.2.7
 - reflection_factory: ^2.3.1
 - postgres: ^2.6.4

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -42,7 +42,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.6.4';
+  static const String VERSION = '1.6.5';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_entity_rules.dart
+++ b/lib/src/bones_api_entity_rules.dart
@@ -6,7 +6,6 @@ import 'bones_api_base.dart';
 import 'bones_api_entity_reference.dart';
 import 'bones_api_extension.dart';
 import 'bones_api_types.dart';
-import 'bones_api_utils_json.dart';
 
 abstract class EntityRules<R extends EntityRules<R>> {
   final bool? _innocuous;
@@ -463,7 +462,14 @@ class EntityAccessRules extends EntityRules<EntityAccessRules> {
 
       Object? map;
       if (enc == null) {
-        map = Json.toJson(o, toEncodable: ReflectionFactory.toJsonEncodable);
+        var classReflection =
+            ReflectionFactory().getRegisterClassReflection(o.runtimeType);
+
+        if (classReflection != null) {
+          map = classReflection.toMapFromFields(o);
+        } else {
+          map = j.toJson(o, autoResetEntityCache: false);
+        }
       } else {
         map = enc(o, j);
       }

--- a/lib/src/bones_api_extension.dart
+++ b/lib/src/bones_api_extension.dart
@@ -1017,6 +1017,8 @@ extension ListOfStringExtension on List<String> {
 extension FutureOrAPIResponseExtension<T> on FutureOr<APIResponse<T>> {
   FutureOr<T?> get payloadAsync => then((r) => r.payload);
 
+  FutureOr<T?> payloadAsyncOr(T? def) => then((r) => r.payload ?? def);
+
   FutureOr<APIResponseStatus> get statusAsync => then((r) => r.status);
 
   FutureOr<Map<String, dynamic>> get headersAsync => then((r) => r.headers);
@@ -1036,6 +1038,8 @@ extension FutureOrAPIResponseExtension<T> on FutureOr<APIResponse<T>> {
 
 extension FutureAPIResponseExtension<T> on Future<APIResponse<T>> {
   Future<T?> get payloadAsync => then((r) => r.payload);
+
+  Future<T?> payloadAsyncOr(T? def) => then((r) => r.payload ?? def);
 
   Future<APIResponseStatus> get statusAsync => then((r) => r.status);
 

--- a/lib/src/bones_api_logging.dart
+++ b/lib/src/bones_api_logging.dart
@@ -73,7 +73,9 @@ extension LoggerExntesion on logging.Logger {
     return handler;
   }
 
-  FutureOr<bool> flushMessages() => handler.flushMessages();
+  FutureOr<bool> flushMessages(
+          {Duration? delay = const Duration(milliseconds: 20)}) =>
+      handler.flushMessages(delay: delay);
 
   static final Set<logging.Logger> _dbLoggers = {};
 
@@ -313,7 +315,8 @@ abstract class LoggerHandler {
 
   void printMessage(logging.Level level, String message);
 
-  FutureOr<bool> flushMessages();
+  FutureOr<bool> flushMessages(
+      {Duration? delay = const Duration(milliseconds: 20)});
 
   void logAll() {
     logging.hierarchicalLoggingEnabled = true;

--- a/lib/src/bones_api_logging_generic.dart
+++ b/lib/src/bones_api_logging_generic.dart
@@ -14,7 +14,8 @@ class LoggerHandlerGeneric extends LoggerHandler {
   }
 
   @override
-  bool flushMessages() => false;
+  bool flushMessages({Duration? delay = const Duration(milliseconds: 20)}) =>
+      false;
 }
 
 LoggerHandler createLoggerHandler(Logger logger) {

--- a/lib/src/bones_api_logging_io.dart
+++ b/lib/src/bones_api_logging_io.dart
@@ -69,9 +69,19 @@ class LoggerHandlerIO extends LoggerHandler {
   }
 
   @override
-  FutureOr<bool> flushMessages() {
-    if (_printMessageQueue.isEmpty) return false;
-    return _scheduleFlushPrintMessageQueue();
+  FutureOr<bool> flushMessages(
+      {Duration? delay = const Duration(milliseconds: 20)}) {
+    if (_printMessageQueue.isEmpty) {
+      if (delay == null) return false;
+
+      return Future.delayed(delay).then((_) {
+        if (_printMessageQueue.isEmpty) return false;
+        return _scheduleFlushPrintMessageQueue();
+      });
+    }
+
+    return _scheduleFlushPrintMessageQueue(
+        delay: delay ?? Duration(milliseconds: 20));
   }
 
   @override

--- a/lib/src/bones_api_server.dart
+++ b/lib/src/bones_api_server.dart
@@ -945,7 +945,7 @@ class APIServer extends _APIServerBase {
       }
     }
 
-    await _log.flushMessages();
+    await _log.flushMessages(delay: Duration(milliseconds: 50));
 
     return true;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A powerful API backend framework for Dart. It comes with a built-in HTTP Server, route handler, entity handler, SQL translator, and DB adapters.
-version: 1.6.4
+version: 1.6.5
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:
@@ -10,9 +10,9 @@ executables:
   bones_api:
 
 dependencies:
-  async_extension: ^1.2.5
+  async_extension: ^1.2.7
   async_events: ^1.1.0
-  reflection_factory: ^2.3.0
+  reflection_factory: ^2.3.1
   statistics: ^1.1.0
   swiss_knife: ^3.2.0
   data_serializer: ^1.1.0
@@ -38,7 +38,7 @@ dependencies:
   logging: ^1.2.0
   collection: ^1.18.0
   mime: ^1.0.5
-  postgres: ^2.6.3
+  postgres: ^2.6.4
   mysql1: ^0.20.0
   gcloud: ^0.8.12
   yaml: ^3.1.2
@@ -47,7 +47,7 @@ dependencies:
   archive: ^3.4.10
   stream_channel: ^2.1.2
   http: ^1.2.1
-  googleapis_auth: ^1.4.1
+  googleapis_auth: ^1.5.0
   crclib: ^3.0.0
 
 dev_dependencies:

--- a/test/bones_api_test.reflection.g.dart
+++ b/test/bones_api_test.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.3.0
+// BUILDER: reflection_factory/2.3.1
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -20,7 +20,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.3.0');
+  static final Version _version = Version.parse('2.3.1');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/test/bones_api_test_entities.reflection.g.dart
+++ b/test/bones_api_test_entities.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.3.0
+// BUILDER: reflection_factory/2.3.1
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -20,7 +20,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.3.0');
+  static final Version _version = Version.parse('2.3.1');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/test/bones_api_test_modules.reflection.g.dart
+++ b/test/bones_api_test_modules.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.3.0
+// BUILDER: reflection_factory/2.3.1
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -20,7 +20,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.3.0');
+  static final Version _version = Version.parse('2.3.1');
 
   Version get reflectionFactoryVersion => _version;
 

--- a/test/bones_api_test_utils_test.reflection.g.dart
+++ b/test/bones_api_test_utils_test.reflection.g.dart
@@ -1,6 +1,6 @@
 //
 // GENERATED CODE - DO NOT MODIFY BY HAND!
-// BUILDER: reflection_factory/2.3.0
+// BUILDER: reflection_factory/2.3.1
 // BUILD COMMAND: dart run build_runner build
 //
 
@@ -20,7 +20,7 @@ typedef __TI<T> = TypeInfo<T>;
 typedef __PR = ParameterReflection;
 
 mixin __ReflectionMixin {
-  static final Version _version = Version.parse('2.3.0');
+  static final Version _version = Version.parse('2.3.1');
 
   Version get reflectionFactoryVersion => _version;
 


### PR DESCRIPTION
- `EntityAccessRules`:
  - Fix `toJsonEncodable` to allow rules to be applied to sub-entities.

- `APIResponse` extension on `Future` and `FutureOr`:
  - Added `payloadAsyncOr`.

- async_extension: ^1.2.7
- reflection_factory: ^2.3.1
- postgres: ^2.6.4
- googleapis_auth: ^1.5.0