### PR TITLE
v1.6.15 - APIModuleProxyHttpCaller.errorHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 1.6.15
+
+- `APIModuleProxyTargetResolver`: added parameter `errorHandler`.
+- `APIModuleProxyCaller.resolveTarget`: added parameter `errorHandler`.
+
+- `APIModuleProxyDirectCaller` and `APIModuleProxyHttpCaller`:
+  - Added field `errorHandler`.
+  - Added static field `defaultErrorHandler`.
+
+- `APIModuleProxyCallerListener`
+  - Added static field `defaultErrorHandler`.
+
+- `APIModuleProxyCallerResponseError`:
+  - Added fields: `request`, `responseStatus`, `module`, `methodName` and `parameters`.
+
+- Removed deprecated `APIModuleHttpProxy` (use `APIModuleProxyHttpCaller`).
+
 ## 1.6.14
 
 - `APIToken`: fix the constructor initialization of field `duration`.

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -42,7 +42,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.6.14';
+  static const String VERSION = '1.6.15';
 
   static bool _boot = false;
 
@@ -66,10 +66,12 @@ abstract class APIRoot with Initializable, Closable {
     BonesAPI.boot();
 
     APIModuleProxyCaller.registerTargetResolver(
-        <T>(target, moduleName, responsesAsJson) {
+        <T>(target, moduleName, responsesAsJson, errorHandler) {
       if (target is APIRoot) {
         return APIModuleProxyDirectCaller<T>(target,
-            moduleName: moduleName ?? '', responsesAsJson: responsesAsJson);
+            moduleName: moduleName ?? '',
+            responsesAsJson: responsesAsJson,
+            errorHandler: errorHandler);
       }
       return null;
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A powerful API backend framework for Dart. It comes with a built-in HTTP Server, route handler, entity handler, SQL translator, and DB adapters.
-version: 1.6.14
+version: 1.6.15
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:


### PR DESCRIPTION
- `APIModuleProxyTargetResolver`: added parameter `errorHandler`.
- `APIModuleProxyCaller.resolveTarget`: added parameter `errorHandler`.

- `APIModuleProxyDirectCaller` and `APIModuleProxyHttpCaller`:
  - Added field `errorHandler`.
  - Added static field `defaultErrorHandler`.

- `APIModuleProxyCallerListener`
  - Added static field `defaultErrorHandler`.

- `APIModuleProxyCallerResponseError`:
  - Added fields: `request`, `responseStatus`, `module`, `methodName` and `parameters`.

- Removed deprecated `APIModuleHttpProxy` (use `APIModuleProxyHttpCaller`).