### PR TITLE
v1.7.6 - selectIDsBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.7.6
+
+- `EntityHandler`:
+  - Added `getIDs`.
+
+- `EntitySource`, `EntityRepository`:
+  - Added `existIDs`, `selectIDsBy` and `selectIDsByQuery`.
+
+- `DBRelationalAdapter`:
+  - Added `parseIDs`.
+
 ## 1.7.5
 
 - New `IterableEntityReferenceExtension` and `IterableEntityReferenceListExtension`.

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -42,7 +42,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.7.5';
+  static const String VERSION = '1.7.6';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_condition_encoder.dart
+++ b/lib/src/bones_api_condition_encoder.dart
@@ -748,12 +748,15 @@ class EncodingContext {
 
   String? tableName;
 
+  String? tableFieldID;
+
   EncodingContext(this.entityName,
       {this.parameters,
       this.positionalParameters,
       this.namedParameters,
       this.transaction,
-      this.tableName});
+      this.tableName,
+      this.tableFieldID});
 
   /// The encoded parameters placeholders and values.
   final Map<String, dynamic> parametersPlaceholders = <String, dynamic>{};
@@ -974,13 +977,15 @@ abstract class ConditionEncoder {
       List? positionalParameters,
       Map<String, Object?>? namedParameters,
       Transaction? transaction,
-      String? tableName}) {
+      String? tableName,
+      String? tableFieldID}) {
     var context = EncodingContext(entityName,
         parameters: parameters,
         positionalParameters: positionalParameters,
         namedParameters: namedParameters,
         transaction: transaction,
-        tableName: tableName);
+        tableName: tableName,
+        tableFieldID: tableFieldID);
 
     if (condition is ConditionANY) {
       return context;

--- a/lib/src/bones_api_entity_db.dart
+++ b/lib/src/bones_api_entity_db.dart
@@ -1223,9 +1223,6 @@ class DBEntityRepository<O extends Object> extends EntityRepository<O>
 
   @override
   FutureOr<bool> existsID(dynamic id, {Transaction? transaction}) {
-    var cachedEntityByID = transaction?.getCachedEntityByID(id, type: type);
-    if (cachedEntityByID != null) return true;
-
     return count(matcher: ConditionID(id), transaction: transaction)
         .resolveMapped((count) => count > 0);
   }

--- a/lib/src/bones_api_entity_db.dart
+++ b/lib/src/bones_api_entity_db.dart
@@ -481,6 +481,9 @@ abstract class DBAdapter<C extends Object> extends SchemeProvider
       Map<String, Object?>? namedParameters,
       PreFinishDBOperation<int, int>? preFinish});
 
+  FutureOr<List<I>> doExistIDs<I extends Object>(
+      TransactionOperation op, String entityName, String table, List<I> ids);
+
   FutureOr<R?> doSelectByID<R>(
       TransactionOperation op, String entityName, String table, Object id,
       {PreFinishDBOperation<Map<String, dynamic>?, R?>? preFinish});
@@ -1129,6 +1132,10 @@ class DBRepositoryAdapter<O> with Initializable {
           namedParameters: namedParameters,
           preFinish: preFinish);
 
+  FutureOr<List<I>> doExistIDs<I extends Object>(
+          TransactionOperation op, List<I> ids) =>
+      databaseAdapter.doExistIDs<I>(op, name, tableName, ids);
+
   FutureOr<R?> doSelectByID<R>(TransactionOperation op, Object id,
           {PreFinishDBOperation<Map<String, dynamic>?, R?>? preFinish}) =>
       databaseAdapter.doSelectByID<R>(op, name, tableName, id,
@@ -1217,10 +1224,55 @@ class DBEntityRepository<O extends Object> extends EntityRepository<O>
   @override
   FutureOr<bool> existsID(dynamic id, {Transaction? transaction}) {
     var cachedEntityByID = transaction?.getCachedEntityByID(id, type: type);
-    if (cachedEntityByID != null) return false;
+    if (cachedEntityByID != null) return true;
 
     return count(matcher: ConditionID(id), transaction: transaction)
         .resolveMapped((count) => count > 0);
+  }
+
+  @override
+  FutureOr<Iterable<I>> existIDs<I extends Object>(List<I?> ids,
+      {Transaction? transaction}) {
+    var idsNotNull = ids is List<I> ? ids : ids.whereNotNull().toList();
+    if (idsNotNull.isEmpty) return <I>[];
+
+    var cachedEntityByIDs =
+        transaction?.getCachedEntitiesByIDs(idsNotNull, type: type);
+
+    var cachedIDs = cachedEntityByIDs?.keys.whereType<I>().toList();
+
+    List<I> notCachedIDs;
+    if (cachedIDs != null) {
+      notCachedIDs = idsNotNull.whereNotIn(cachedIDs).toList();
+      if (notCachedIDs.isEmpty) {
+        return idsNotNull;
+      }
+    } else {
+      notCachedIDs = idsNotNull;
+    }
+
+    checkNotClosed();
+
+    var op = TransactionOperationCount(name, operationExecutor,
+        matcher: ConditionIdIN(notCachedIDs), transaction: transaction);
+
+    try {
+      return repositoryAdapter
+          .doExistIDs(op, notCachedIDs)
+          .resolveMapped((ids) {
+        return [
+          ...?cachedIDs,
+          ...ids,
+        ];
+      });
+    } catch (e, s) {
+      var message = 'existIDs> '
+          'cachedIDs: $cachedIDs ; '
+          'notCachedIDs: $notCachedIDs ; '
+          'op: $op';
+      _log.severe(message, e, s);
+      rethrow;
+    }
   }
 
   @override
@@ -1331,6 +1383,28 @@ class DBEntityRepository<O extends Object> extends EntityRepository<O>
 
     if (matcher is ConditionANY) {
       return _selectAll(transaction, matcher, resolutionRules);
+    }
+
+    throw UnsupportedError(
+        "Relationship select not supported for: (${matcher.runtimeTypeNameUnsafe}) $matcher @ $tableName ($this)");
+  }
+
+  @override
+  FutureOr<Iterable<I>> selectIDsBy<I extends Object>(EntityMatcher matcher,
+      {Object? parameters,
+      List? positionalParameters,
+      Map<String, Object?>? namedParameters,
+      Transaction? transaction,
+      int? limit}) {
+    if (matcher is ConditionID) {
+      var id = matcher.idValue;
+      return existsID(id, transaction: transaction)
+          .resolveMapped((exists) => exists ? [id] : []);
+    }
+
+    if (matcher is ConditionIdIN) {
+      var ids = matcher.idsValues.whereType<I>().toList();
+      return existIDs(ids, transaction: transaction);
     }
 
     throw UnsupportedError(

--- a/lib/src/bones_api_entity_db_memory.dart
+++ b/lib/src/bones_api_entity_db_memory.dart
@@ -7,6 +7,7 @@ import 'package:reflection_factory/reflection_factory.dart';
 import 'package:statistics/statistics.dart';
 
 import 'bones_api_condition_encoder.dart';
+import 'bones_api_condition.dart';
 import 'bones_api_entity.dart';
 import 'bones_api_entity_annotation.dart';
 import 'bones_api_entity_db_sql.dart';
@@ -410,6 +411,28 @@ class DBSQLMemoryAdapter extends DBSQLAdapter<DBSQLMemoryAdapterContext>
     } else {
       return map.length;
     }
+  }
+
+  @override
+  FutureOr<List<I>> doExistIDsSQL<I extends Object>(
+      String entityName,
+      String table,
+      SQL sql,
+      Transaction transaction,
+      DBSQLMemoryAdapterContext connection) {
+    var map = _getTableMap(table, false);
+    if (map == null) return [];
+
+    var condition = sql.condition;
+    if (condition is! ConditionIdIN) {
+      return [];
+    }
+
+    var ids = condition.idsValues;
+
+    var existIDs = map.keys.whereIn(ids).whereType<I>().toList();
+
+    return existIDs;
   }
 
   @override

--- a/lib/src/bones_api_entity_db_mysql.dart
+++ b/lib/src/bones_api_entity_db_mysql.dart
@@ -644,6 +644,27 @@ class DBMySQLAdapter extends DBSQLAdapter<DBMySqlConnectionWrapper>
   }
 
   @override
+  FutureOr<List<I>> doExistIDsSQL<I extends Object>(
+      String entityName,
+      String table,
+      SQL sql,
+      Transaction transaction,
+      DBMySqlConnectionWrapper connection) {
+    if (sql.isDummy) return <I>[];
+
+    return connection
+        .query(sql.sqlPositional, sql.parametersValuesByPosition)
+        .resolveMapped((results) {
+      var ids = results
+          .map((e) => e.fields)
+          .whereType<Map<String, dynamic>>()
+          .map((e) => e['id']);
+
+      return parseIDs<I>(ids);
+    });
+  }
+
+  @override
   FutureOr<Iterable<Map<String, dynamic>>> doSelectSQL(
       String entityName,
       String table,

--- a/lib/src/bones_api_entity_db_object_directory.dart
+++ b/lib/src/bones_api_entity_db_object_directory.dart
@@ -362,6 +362,28 @@ class DBObjectDirectoryAdapter
       _listTablesDirs().map((d) => pack_path.split(d.path).last).toList();
 
   @override
+  FutureOr<List<I>> doExistIDs<I extends Object>(
+      TransactionOperation op, String entityName, String table, List<I> ids) {
+    return executeTransactionOperation(
+        op,
+        (conn) => _doExistIDsImpl(op, table, ids)
+            .resolveMapped((res) => _finishOperation(op, res, null)));
+  }
+
+  List<I> _doExistIDsImpl<I extends Object>(
+      TransactionOperation op, String table, List<I> ids) {
+    var tableDir = _resolveTableDirectory(table);
+    if (!tableDir.existsSync()) return [];
+
+    var existIDs = ids.where((id) {
+      var objFile = _resolveObjectFile(table, id);
+      return objFile.existsSync();
+    }).toList();
+
+    return existIDs;
+  }
+
+  @override
   FutureOr<R?> doSelectByID<R>(
           TransactionOperation op, String entityName, String table, Object id,
           {PreFinishDBOperation<Map<String, dynamic>?, R?>? preFinish}) =>

--- a/lib/src/bones_api_entity_db_object_memory.dart
+++ b/lib/src/bones_api_entity_db_object_memory.dart
@@ -5,6 +5,7 @@ import 'package:collection/collection.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:map_history/map_history.dart';
 import 'package:reflection_factory/reflection_factory.dart';
+import 'package:statistics/statistics.dart';
 
 import 'bones_api_condition.dart';
 import 'bones_api_condition_encoder.dart';
@@ -427,6 +428,25 @@ class DBObjectMemoryAdapter
     }
 
     return map.length;
+  }
+
+  @override
+  FutureOr<List<I>> doExistIDs<I extends Object>(
+      TransactionOperation op, String entityName, String table, List<I> ids) {
+    return executeTransactionOperation(
+        op,
+        (conn) => _doExistIDsImpl(op, table, ids)
+            .resolveMapped((res) => _finishOperation(op, res, null)));
+  }
+
+  List<I> _doExistIDsImpl<I extends Object>(
+      TransactionOperation op, String table, List<I> ids) {
+    var map = _getTableMap(table, false);
+    if (map == null) return [];
+
+    var oIDs = map.keys.whereIn(ids).whereType<I>().toList();
+
+    return oIDs;
   }
 
   @override

--- a/lib/src/bones_api_entity_db_postgres.dart
+++ b/lib/src/bones_api_entity_db_postgres.dart
@@ -884,6 +884,28 @@ class DBPostgreSQLAdapter extends DBSQLAdapter<PostgreSQLConnectionWrapper>
   }
 
   @override
+  FutureOr<List<I>> doExistIDsSQL<I extends Object>(
+      String entityName,
+      String table,
+      SQL sql,
+      Transaction transaction,
+      PostgreSQLConnectionWrapper connection) {
+    if (sql.isDummy) return <I>[];
+
+    return connection
+        .mappedResultsQuery(sql.sql,
+            substitutionValues: sql.parametersByPlaceholder)
+        .resolveMapped((results) {
+      var ids = results
+          .map((e) => e[table])
+          .whereType<Map<String, dynamic>>()
+          .map((e) => e['id']);
+
+      return parseIDs<I>(ids);
+    });
+  }
+
+  @override
   FutureOr<Iterable<Map<String, dynamic>>> doSelectSQL(
       String entityName,
       String table,

--- a/lib/src/bones_api_entity_db_relational.dart
+++ b/lib/src/bones_api_entity_db_relational.dart
@@ -366,12 +366,6 @@ class DBRelationalEntityRepository<O extends Object>
   }
 
   @override
-  FutureOr<Iterable<I>> existIDs<I extends Object>(List<I?> ids,
-      {Transaction? transaction}) {
-    return selectIDsBy(ConditionIdIN(ids), transaction: transaction);
-  }
-
-  @override
   FutureOr<Iterable<I>> selectIDsBy<I extends Object>(EntityMatcher matcher,
       {Object? parameters,
       List? positionalParameters,

--- a/lib/src/bones_api_repository.dart
+++ b/lib/src/bones_api_repository.dart
@@ -141,6 +141,32 @@ abstract class APIRepository<O extends Object> with Initializable {
           transaction: transaction,
           resolutionRules: resolutionRules);
 
+  FutureOr<Iterable<I>> selectIDsByQuery<I extends Object>(String query,
+          {Object? parameters,
+          List? positionalParameters,
+          Map<String, Object?>? namedParameters,
+          int? limit,
+          Transaction? transaction}) =>
+      entityRepository.selectIDsByQuery<I>(query,
+          parameters: parameters,
+          positionalParameters: positionalParameters,
+          namedParameters: namedParameters,
+          limit: limit,
+          transaction: transaction);
+
+  FutureOr<Iterable<I>> selectIDsBy<I extends Object>(EntityMatcher<O> matcher,
+          {Object? parameters,
+          List? positionalParameters,
+          Map<String, Object?>? namedParameters,
+          int? limit,
+          Transaction? transaction}) =>
+      entityRepository.selectIDsBy(matcher,
+          parameters: parameters,
+          positionalParameters: positionalParameters,
+          namedParameters: namedParameters,
+          limit: limit,
+          transaction: transaction);
+
   FutureOr<Iterable<O>> select(EntityMatcher<O> matcher,
           {Object? parameters,
           List? positionalParameters,

--- a/lib/src/bones_api_repository.dart
+++ b/lib/src/bones_api_repository.dart
@@ -90,6 +90,10 @@ abstract class APIRepository<O extends Object> with Initializable {
   FutureOr<bool> existsID(dynamic id, {Transaction? transaction}) =>
       entityRepository.existsID(id, transaction: transaction);
 
+  FutureOr<Iterable<I>> existIDs<I extends Object>(List<I?> ids,
+          {Transaction? transaction}) =>
+      entityRepository.existIDs(ids, transaction: transaction);
+
   FutureOr<O?> selectByID(dynamic id,
           {Transaction? transaction, EntityResolutionRules? resolutionRules}) =>
       entityRepository.selectByID(id,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A powerful API backend framework for Dart. It comes with a built-in HTTP Server, route handler, entity handler, SQL translator, and DB adapters.
-version: 1.7.5
+version: 1.7.6
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:


### PR DESCRIPTION
- `EntityHandler`:
  - Added `getIDs`.

- `EntitySource`, `EntityRepository`:
  - Added `existIDs`, `selectIDsBy` and `selectIDsByQuery`.

- `DBRelationalAdapter`:
  - Added `parseIDs`.