### PR TITLE
v1.7.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - `APIModuleProxyHttpCaller`:
   - Optimize `parseResponse`.
+  - `doRequest`:
+    - Added parameter `returnType`.
+   - Only use `responseType = 'arraybuffer'` if the `returnType` is `Uint8List`; otherwise, use `responseType = 'text'`.
 
 - statistics: ^1.1.3
 - swiss_knife: ^3.2.2


### PR DESCRIPTION
- `APIModuleProxyHttpCaller`:
  - Optimize `parseResponse`.
  - `doRequest`:
    - Added parameter `returnType`.
   - Only use `responseType = 'arraybuffer'` if the `returnType` is `Uint8List`; otherwise, use `responseType = 'text'`.

- statistics: ^1.1.3
- swiss_knife: ^3.2.2
- mercury_client: ^2.2.3
- shelf_static: ^1.1.3
- gcloud: ^0.8.13