### PR TITLE
v1.7.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.7.23
+
+- `SQL`:
+  - Added `copy`, `isSharedDummy`, and `ensureNotSharedDummy`.
+  - Fix `generateInsertRelationshipSQLs`: use `ensureNotSharedDummy`.
+
+- meta: ^1.16.0
+
 ## 1.7.22
 
 - `APIModuleProxyHttpCaller`:

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -42,7 +42,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.7.22';
+  static const String VERSION = '1.7.23';
 
   static bool _boot = false;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A powerful API backend framework for Dart. It comes with a built-in HTTP Server, route handler, entity handler, SQL translator, and DB adapters.
-version: 1.7.22
+version: 1.7.23
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:
@@ -32,7 +32,7 @@ dependencies:
   shelf_gzip: ^4.1.0
   shelf_static: ^1.1.3
   args: ^2.5.0
-  meta: ^1.15.0
+  meta: ^1.16.0
   petitparser: ^6.0.2
   hotreloader: ^4.2.0
   logging: ^1.2.0


### PR DESCRIPTION
- `SQL`:
  - Added `copy`, `isSharedDummy`, and `ensureNotSharedDummy`.
  - Fix `generateInsertRelationshipSQLs`: use `ensureNotSharedDummy`.