### PR TITLE
v1.7.28 - Fix `EntityAccessRules._simplified` parameter `masker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.7.28
+
+- `EntityAccessRules._simplified`:
+  - Fix: Added parameter `masker`.
+
 ## 1.7.27
 
 - `EntityAccessRuleType`:

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -42,7 +42,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.7.27';
+  static const String VERSION = '1.7.28';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_entity_rules.dart
+++ b/lib/src/bones_api_entity_rules.dart
@@ -119,9 +119,8 @@ class EntityAccessRules extends EntityRules<EntityAccessRules> {
             rules == null);
 
   const EntityAccessRules._simplified(this.ruleType, this.entityType,
-      this.entityFields, this.rules, this.condition)
-      : masker = null,
-        _simplified = true,
+      this.entityFields, this.rules, this.condition, this.masker)
+      : _simplified = true,
         super(false);
 
   const EntityAccessRules.group(List<EntityAccessRules> rules)
@@ -496,8 +495,8 @@ class EntityAccessRules extends EntityRules<EntityAccessRules> {
 
     return s._isInnocuousImpl()
         ? EntityAccessRules.innocuous
-        : EntityAccessRules._simplified(
-            s.ruleType, s.entityType, s.entityFields, s.rules, s.condition);
+        : EntityAccessRules._simplified(s.ruleType, s.entityType,
+            s.entityFields, s.rules, s.condition, s.masker);
   }
 
   EntityAccessRules _simplifiedImpl() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,11 +60,11 @@ dev_dependencies:
   coverage: ^1.11.0
   vm_service: ^13.0.0
 
-dependency_overrides:
+#dependency_overrides:
 #  shared_map:
 #    path: ../shared_map
-  shelf_letsencrypt:
-    path: ../shelf_letsencrypt
+#  shelf_letsencrypt:
+#    path: ../shelf_letsencrypt
 #  args_simple:
 #    path: ../args_simple
 #  graph_explorer:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A powerful API backend framework for Dart. It comes with a built-in HTTP Server, route handler, entity handler, SQL translator, and DB adapters.
-version: 1.7.27
+version: 1.7.28
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:
@@ -60,11 +60,11 @@ dev_dependencies:
   coverage: ^1.11.0
   vm_service: ^13.0.0
 
-#dependency_overrides:
+dependency_overrides:
 #  shared_map:
 #    path: ../shared_map
-#  shelf_letsencrypt:
-#    path: ../shelf_letsencrypt
+  shelf_letsencrypt:
+    path: ../shelf_letsencrypt
 #  args_simple:
 #    path: ../args_simple
 #  graph_explorer:

--- a/test/bones_api_entity_rules_test.dart
+++ b/test/bones_api_entity_rules_test.dart
@@ -194,6 +194,14 @@ void main() {
     testMaskFields(bool cached) {
       var r1 = EntityAccessRules.maskFields(User, ['email', 'password']);
 
+      var r1s = r1.simplified();
+      expect(identical(r1.ruleType, r1s.ruleType), isTrue);
+      expect(identical(r1.entityType, r1s.entityType), isTrue);
+      expect(identical(r1.condition, r1s.condition), isTrue);
+      expect(identical(r1.masker, r1s.masker), isTrue);
+      expect(r1s.entityFields, equals((r1.entityFields)));
+      expect(r1s.rules, equals((r1.rules)));
+
       if (cached) {
         r1 = r1.cached;
       }
@@ -249,6 +257,14 @@ void main() {
           }
         }),
       ]);
+
+      var r1s = r1.simplified();
+      expect(identical(r1.ruleType, r1s.ruleType), isTrue);
+      expect(identical(r1.entityType, r1s.entityType), isTrue);
+      expect(identical(r1.condition, r1s.condition), isTrue);
+      expect(identical(r1.masker, r1s.masker), isTrue);
+      expect(r1s.entityFields, equals((r1.entityFields)));
+      expect(r1s.rules, equals((r1.rules)));
 
       if (cached) {
         r1 = r1.cached;


### PR DESCRIPTION
- `EntityAccessRules._simplified`:
  - Fix: Added parameter `masker`.