### PR TITLE
v1.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.8.5
+
+- refactor(api):
+  - 🔨 improve payload handling in resolveBody and resolveBodySync
+  - 🔨 `UNAUTHORIZED`, `BAD_REQUEST`: Allow `error` as `payload` in response generation.
+
+- swiss_knife: ^3.2.3
+- yaml: ^3.1.3
+- stream_channel: ^2.1.3
+
 ## 1.8.4
 
 - `APIRoot`:

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -42,7 +42,7 @@ typedef APILogger = void Function(APIRoot apiRoot, String type, String? message,
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.8.4';
+  static const String VERSION = '1.8.5';
 
   static bool _boot = false;
 
@@ -2798,12 +2798,14 @@ class APIResponse<T> extends APIMetricSet with APIPayload {
       T? payload,
       Object? payloadDynamic,
       Object? mimeType,
+      Object? error,
       Map<String, APIMetric>? metrics}) {
     return APIResponse(APIResponseStatus.UNAUTHORIZED,
         headers: headers ?? <String, dynamic>{},
         payload: payload,
         payloadDynamic: payloadDynamic,
         payloadMimeType: mimeType,
+        error: error,
         metrics: metrics);
   }
 
@@ -2876,12 +2878,14 @@ class APIResponse<T> extends APIMetricSet with APIPayload {
       T? payload,
       Object? payloadDynamic,
       Object? mimeType,
+      Object? error,
       Map<String, APIMetric>? metrics}) {
     return APIResponse(APIResponseStatus.BAD_REQUEST,
         headers: headers ?? <String, dynamic>{},
         payload: payload,
         payloadDynamic: payloadDynamic,
         payloadMimeType: mimeType,
+        error: error,
         metrics: metrics);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A powerful API backend framework for Dart. It comes with a built-in HTTP Server, route handler, entity handler, SQL translator, and DB adapters.
-version: 1.8.4
+version: 1.8.5
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:
@@ -14,7 +14,7 @@ dependencies:
   async_events: ^1.2.0
   reflection_factory: ^2.4.8
   statistics: ^1.1.3
-  swiss_knife: ^3.2.2
+  swiss_knife: ^3.2.3
   data_serializer: ^1.2.1
   shared_map: ^1.1.9
   graph_explorer: ^1.0.2
@@ -41,11 +41,11 @@ dependencies:
   postgres: ^2.6.4
   mysql1: ^0.20.0
   gcloud: ^0.8.18
-  yaml: ^3.1.2
+  yaml: ^3.1.3
   crypto: ^3.0.6
   path: ^1.9.1
   archive: ^3.6.1
-  stream_channel: ^2.1.2
+  stream_channel: ^2.1.3
   http: ^1.2.2
   googleapis_auth: ^1.6.0
   crclib: ^3.0.0


### PR DESCRIPTION
- refactor(api):
  - 🔨 improve payload handling in resolveBody and resolveBodySync
  - 🔨 `UNAUTHORIZED`, `BAD_REQUEST`: Allow `error` as `payload` in response generation.

- swiss_knife: ^3.2.3
- yaml: ^3.1.3
- stream_channel: ^2.1.3