### PR TITLE
v1.9.29 - Feature: DBEntityRepository.select: allow query ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,25 @@
 ## 1.9.29
 
+- `ConditionID`:
+  - Added method `resolveIDValue` to resolve the ID value from parameters or `ConditionParameter`.
+
 - `DBEntityRepository`:
+  - Updated `selectIDsBy` and `_selectByID` to use `ConditionID.resolveIDValue` for ID resolution.
   - `select`:
     - Added optimization for `KeyConditionEQ` matcher with a single key matching the entity ID field.
     - When matched, uses `_selectByID` to fetch the entity by ID and returns a single-element list or empty list accordingly.
+
+- `DBObjectDirectoryAdapter`:
+  - Updated `_doCountImpl` and `_doDeleteImpl` to use `ConditionID.resolveIDValue` for ID resolution.
+  - Updated public methods to pass combined parameters (`parameters ?? namedParameters`) to internal implementations.
+
+- `DBObjectGCSAdapter`:
+  - Updated `_doCountImpl` and `_doDeleteImpl` to use `ConditionID.resolveIDValue` for ID resolution.
+  - Updated public methods to pass combined parameters (`parameters ?? namedParameters`) to internal implementations.
+
+- `DBObjectMemoryAdapter`:
+  - Updated `_doCountImpl` and `_doDeleteImpl` to use `ConditionID.resolveIDValue` for ID resolution.
+  - Updated public methods to pass combined parameters (`parameters ?? namedParameters`) to internal implementations.
 
 - Dependency updates:
   - `vm_service`: ^15.0.2 → ^15.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.9.29
+
+- `DBEntityRepository`:
+  - `select`:
+    - Added optimization for `KeyConditionEQ` matcher with a single key matching the entity ID field.
+    - When matched, uses `_selectByID` to fetch the entity by ID and returns a single-element list or empty list accordingly.
+
+- Dependency updates:
+  - `vm_service`: ^15.0.2 → ^15.1.0
+
 ## 1.9.28
 
 - `SQLGenerator`:

--- a/lib/src/bones_api_base.dart
+++ b/lib/src/bones_api_base.dart
@@ -48,7 +48,7 @@ typedef APILogger =
 /// Bones API Library class.
 class BonesAPI {
   // ignore: constant_identifier_names
-  static const String VERSION = '1.9.28';
+  static const String VERSION = '1.9.29';
 
   static bool _boot = false;
 

--- a/lib/src/bones_api_condition.dart
+++ b/lib/src/bones_api_condition.dart
@@ -1014,6 +1014,20 @@ class ConditionID<O> extends Condition<O> {
 
   ConditionID([this.idValue]) : super._();
 
+  dynamic resolveIDValue({Object? parameters}) {
+    var id = idValue;
+
+    if (id == null && parameters is O) {
+      id = getID(parameters);
+    }
+
+    if (id is ConditionParameter) {
+      id = id.getValue(parameters: parameters);
+    }
+
+    return id;
+  }
+
   @override
   bool get isIDCondition => true;
 

--- a/lib/src/bones_api_entity_db.dart
+++ b/lib/src/bones_api_entity_db.dart
@@ -1671,6 +1671,30 @@ class DBEntityRepository<O extends Object> extends EntityRepository<O>
       return _selectAll(transaction, matcher, resolutionRules);
     }
 
+    if (matcher is KeyConditionEQ) {
+      var keys = matcher.keys;
+      if (keys.length == 1) {
+        var conditionKey = matcher.keys.first;
+
+        if (conditionKey is ConditionKeyField) {
+          var key = conditionKey.name;
+          var idFieldName = entityHandler.idFieldName();
+
+          if (idFieldName == key) {
+            var idValue = matcher.value;
+            var matcherID = ConditionID(idValue);
+
+            return _selectByID(
+              transaction,
+              matcherID,
+              parameters ?? namedParameters,
+              resolutionRules,
+            ).resolveMapped((res) => res != null ? <O>[res] : <O>[]);
+          }
+        }
+      }
+    }
+
     throw UnsupportedError(
       "Relationship select not supported for: (${matcher.runtimeTypeNameUnsafe}) $matcher @ $tableName ($this)",
     );

--- a/lib/src/bones_api_entity_db.dart
+++ b/lib/src/bones_api_entity_db.dart
@@ -1710,7 +1710,9 @@ class DBEntityRepository<O extends Object> extends EntityRepository<O>
     int? limit,
   }) {
     if (matcher is ConditionID) {
-      var id = matcher.idValue;
+      var id = matcher.resolveIDValue(
+        parameters: parameters ?? namedParameters,
+      );
       return existsID(
         id,
         transaction: transaction,
@@ -1733,7 +1735,7 @@ class DBEntityRepository<O extends Object> extends EntityRepository<O>
     Object? parameters,
     EntityResolutionRules? resolutionRules,
   ) {
-    var id = matcher.idValue ?? matcher.getID(parameters);
+    var id = matcher.resolveIDValue(parameters: parameters);
 
     if (id == null && parameters != null) {
       id = matcher.getID(parameters);

--- a/lib/src/bones_api_entity_db_object_directory.dart
+++ b/lib/src/bones_api_entity_db_object_directory.dart
@@ -371,7 +371,7 @@ class DBObjectDirectoryAdapter
         op,
         table,
         matcher,
-        parameters,
+        parameters ?? namedParameters,
       ).resolveMapped((res) => _finishOperation(op, res, preFinish)),
     );
   }
@@ -387,7 +387,7 @@ class DBObjectDirectoryAdapter
 
     if (matcher != null) {
       if (matcher is ConditionID) {
-        var id = matcher.idValue ?? matcher.getID(parameters);
+        var id = matcher.resolveIDValue(parameters: parameters);
 
         var objFile = _resolveObjectFile(table, id);
         return objFile.existsSync() ? 1 : 0;
@@ -558,7 +558,7 @@ class DBObjectDirectoryAdapter
       op,
       table,
       matcher,
-      parameters,
+      parameters ?? namedParameters,
     ).resolveMapped((res) => _finishOperation(op, res, preFinish)),
   );
 
@@ -572,7 +572,7 @@ class DBObjectDirectoryAdapter
     if (!tableDir.existsSync()) return [];
 
     if (matcher is ConditionID) {
-      var id = matcher.idValue ?? matcher.getID(parameters);
+      var id = matcher.resolveIDValue(parameters: parameters);
 
       var objFile = _resolveObjectFile(table, id);
       if (!objFile.existsSync()) return [];

--- a/lib/src/bones_api_entity_db_object_gcs.dart
+++ b/lib/src/bones_api_entity_db_object_gcs.dart
@@ -479,7 +479,7 @@ class DBObjectGCSAdapter extends DBObjectAdapter<DBObjectGCSAdapterContext> {
         op,
         table,
         matcher,
-        parameters,
+        parameters ?? namedParameters,
       ).resolveMapped((res) => _finishOperation(op, res, preFinish)),
     );
   }
@@ -492,7 +492,7 @@ class DBObjectGCSAdapter extends DBObjectAdapter<DBObjectGCSAdapterContext> {
   ) async {
     if (matcher != null) {
       if (matcher is ConditionID) {
-        var id = matcher.idValue ?? matcher.getID(parameters);
+        var id = matcher.resolveIDValue(parameters: parameters);
 
         var objFile = _resolveObjectFilePath(table, id);
 
@@ -646,7 +646,7 @@ class DBObjectGCSAdapter extends DBObjectAdapter<DBObjectGCSAdapterContext> {
       op,
       table,
       matcher,
-      parameters,
+      parameters ?? namedParameters,
     ).resolveMapped((res) => _finishOperation(op, res, preFinish)),
   );
 
@@ -657,7 +657,7 @@ class DBObjectGCSAdapter extends DBObjectAdapter<DBObjectGCSAdapterContext> {
     Object? parameters,
   ) async {
     if (matcher is ConditionID) {
-      var id = matcher.idValue ?? matcher.getID(parameters);
+      var id = matcher.resolveIDValue(parameters: parameters);
 
       var entry = await _deleteObject(table, id);
 

--- a/lib/src/bones_api_entity_db_object_memory.dart
+++ b/lib/src/bones_api_entity_db_object_memory.dart
@@ -438,7 +438,7 @@ class DBObjectMemoryAdapter
         op,
         table,
         matcher,
-        parameters,
+        parameters ?? namedParameters,
       ).resolveMapped((res) => _finishOperation(op, res, preFinish)),
     );
   }
@@ -454,7 +454,7 @@ class DBObjectMemoryAdapter
 
     if (matcher != null) {
       if (matcher is ConditionID) {
-        var id = matcher.idValue ?? matcher.getID(parameters);
+        var id = matcher.resolveIDValue(parameters: parameters);
         return map.containsKey(id) ? 1 : 0;
       }
 
@@ -609,7 +609,7 @@ class DBObjectMemoryAdapter
       op,
       table,
       matcher,
-      parameters,
+      parameters ?? namedParameters,
     ).resolveMapped((res) => _finishOperation(op, res, preFinish)),
   );
 
@@ -623,7 +623,7 @@ class DBObjectMemoryAdapter
     if (map == null) return [];
 
     if (matcher is ConditionID) {
-      var id = matcher.idValue ?? matcher.getID(parameters);
+      var id = matcher.resolveIDValue(parameters: parameters);
       var entry = map.remove(id);
       return entry != null ? [entry] : [];
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bones_api
 description: Bones_API - A powerful API backend framework for Dart. It comes with a built-in HTTP Server, route handler, entity handler, SQL translator, and DB adapters.
-version: 1.9.28
+version: 1.9.29
 homepage: https://github.com/Colossus-Services/bones_api
 
 environment:
@@ -61,7 +61,7 @@ dev_dependencies:
   pubspec: ^2.3.0
   #dependency_validator: ^4.1.3
   coverage: ^1.15.0
-  vm_service: ^15.0.2
+  vm_service: ^15.1.0
 
 #dependency_overrides:
 #  shared_map:

--- a/test/bones_api_entity_db_tests_base.dart
+++ b/test/bones_api_entity_db_tests_base.dart
@@ -791,6 +791,24 @@ Future<bool> runAdapterTests(
 
           expect((await photoAPIRepository.existsID(png1PixelSha256)), isTrue);
 
+          expect(
+            (await photoAPIRepository.selectByID(png1PixelSha256)),
+            equals(photo),
+          );
+
+          expect(
+            (await photoAPIRepository.selectByIDs([png1PixelSha256, "nope"])),
+            equals([photo, null]),
+          );
+
+          expect(
+            (await photoAPIRepository.selectByQuery(
+              'id == ?',
+              parameters: {'id': photo.id},
+            )),
+            equals([photo]),
+          );
+
           {
             var address1 = await addressAPIRepository.selectByID(address.id);
             expect(address1, isNotNull);


### PR DESCRIPTION
- `DBEntityRepository`:
  - `select`:
    - Added optimization for `KeyConditionEQ` matcher with a single key matching the entity ID field.
    - When matched, uses `_selectByID` to fetch the entity by ID and returns a single-element list or empty list accordingly.

- Dependency updates:
  - `vm_service`: ^15.0.2 → ^15.1.0